### PR TITLE
Make last_enqueue_time be always an instance of Time.

### DIFF
--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -409,7 +409,7 @@ module Sidekiq
           active_job: @active_job ? "1" : "0",
           queue_name_prefix: @active_job_queue_name_prefix,
           queue_name_delimiter: @active_job_queue_name_delimiter,
-          last_enqueue_time: @last_enqueue_time.to_s,
+          last_enqueue_time: serialized_last_enqueue_time,
           symbolize_args: symbolize_args? ? "1" : "0",
         }
 
@@ -477,7 +477,7 @@ module Sidekiq
       def save_last_enqueue_time
         Sidekiq.redis do |conn|
           # Update last enqueue time.
-          conn.hset redis_key, 'last_enqueue_time', @last_enqueue_time.strftime(LAST_ENQUEUE_TIME_FORMAT)
+          conn.hset redis_key, 'last_enqueue_time', serialized_last_enqueue_time
         end
       end
 
@@ -656,8 +656,11 @@ module Sidekiq
 
       # Give Hash returns array for using it for redis.hmset
       def hash_to_redis hash
-        hash[:last_enqueue_time] = hash[:last_enqueue_time]&.strftime(LAST_ENQUEUE_TIME_FORMAT)
         hash.flat_map{ |key, value| [key, value || ""] }
+      end
+
+      def serialized_last_enqueue_time
+        @last_enqueue_time&.strftime(LAST_ENQUEUE_TIME_FORMAT)
       end
     end
   end

--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -46,7 +46,7 @@ module Sidekiq
 
       # Enqueue cron job to queue.
       def enque! time = Time.now.utc
-        @last_enqueue_time = time.strftime(LAST_ENQUEUE_TIME_FORMAT)
+        @last_enqueue_time = time
 
         klass_const =
             begin
@@ -480,7 +480,7 @@ module Sidekiq
       def save_last_enqueue_time
         Sidekiq.redis do |conn|
           # Update last enqueue time.
-          conn.hset redis_key, 'last_enqueue_time', @last_enqueue_time
+          conn.hset redis_key, 'last_enqueue_time', @last_enqueue_time.strftime(LAST_ENQUEUE_TIME_FORMAT)
         end
       end
 
@@ -672,6 +672,7 @@ module Sidekiq
 
       # Give Hash returns array for using it for redis.hmset
       def hash_to_redis hash
+        hash[:last_enqueue_time] = hash[:last_enqueue_time]&.strftime(LAST_ENQUEUE_TIME_FORMAT)
         hash.inject([]){ |arr,kv| arr + [kv[0], kv[1]] }
       end
     end


### PR DESCRIPTION
On my laptop in Japanese-language environment, loading `@last_enqueue_time` raises a parse error:

```
2022-08-08T05:59:06.992Z pid=58672 tid=2kqk WARN: Date::Error: invalid date
2022-08-08T05:59:06.992Z pid=58672 tid=2kqk WARN: /Users/ryotarai/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/sidekiq-cron-1.7.0/lib/sidekiq/cron/job.rb:632:in `parse'
/Users/ryotarai/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/sidekiq-cron-1.7.0/lib/sidekiq/cron/job.rb:632:in `rescue in parse_enqueue_time'
/Users/ryotarai/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/sidekiq-cron-1.7.0/lib/sidekiq/cron/job.rb:629:in `parse_enqueue_time'
/Users/ryotarai/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/sidekiq-cron-1.7.0/lib/sidekiq/cron/job.rb:285:in `initialize'
```

![image](https://user-images.githubusercontent.com/706434/183349600-8c675b48-1ce8-4bfe-8b3e-571518b2ad5b.png)

This PR makes `@last_enqueue_time` be always Time instance.

Closes #397 