### PR TITLE
simplify test_helper.rb + remove dev dep redis-namespace + update links to new home

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,41 +4,41 @@ All notable changes to this project will be documented in this file.
 
 ## 1.8.0
 
-- Fix deprecation warnings with redis-rb v4.8.0 (https://github.com/ondrejbartas/sidekiq-cron/pull/356)
-- Fix poller affecting Sidekiq scheduled set poller (https://github.com/ondrejbartas/sidekiq-cron/pull/359)
-- Fix default polling interval (https://github.com/ondrejbartas/sidekiq-cron/pull/362)
-- Add italian locale (https://github.com/ondrejbartas/sidekiq-cron/pull/367)
-- Allow disabling of cron polling (https://github.com/ondrejbartas/sidekiq-cron/pull/368)
+- Fix deprecation warnings with redis-rb v4.8.0 (https://github.com/sidekiq-cron/sidekiq-cron/pull/356)
+- Fix poller affecting Sidekiq scheduled set poller (https://github.com/sidekiq-cron/sidekiq-cron/pull/359)
+- Fix default polling interval (https://github.com/sidekiq-cron/sidekiq-cron/pull/362)
+- Add italian locale (https://github.com/sidekiq-cron/sidekiq-cron/pull/367)
+- Allow disabling of cron polling (https://github.com/sidekiq-cron/sidekiq-cron/pull/368)
 
 ## 1.7.0
 
-- Enable to use cron notation in natural language (ie `every 30 minutes`) (https://github.com/ondrejbartas/sidekiq-cron/pull/312)
-- Fix `date_as_argument` feature to add timestamp argument at every cron job execution (https://github.com/ondrejbartas/sidekiq-cron/pull/329)
-- Introduce `Sidekiq::Options` to centralize reading/writing options from different Sidekiq versions (https://github.com/ondrejbartas/sidekiq-cron/pull/341)
-- Make auto schedule loading compatible with Array format (https://github.com/ondrejbartas/sidekiq-cron/pull/345)
+- Enable to use cron notation in natural language (ie `every 30 minutes`) (https://github.com/sidekiq-cron/sidekiq-cron/pull/312)
+- Fix `date_as_argument` feature to add timestamp argument at every cron job execution (https://github.com/sidekiq-cron/sidekiq-cron/pull/329)
+- Introduce `Sidekiq::Options` to centralize reading/writing options from different Sidekiq versions (https://github.com/sidekiq-cron/sidekiq-cron/pull/341)
+- Make auto schedule loading compatible with Array format (https://github.com/sidekiq-cron/sidekiq-cron/pull/345)
 
 ## 1.6.0
 
-- Adds support for auto-loading the `config/schedule.yml` file (https://github.com/ondrejbartas/sidekiq-cron/pull/337)
-- Fix `Sidekiq.options` deprecation warning (https://github.com/ondrejbartas/sidekiq-cron/pull/338)
+- Adds support for auto-loading the `config/schedule.yml` file (https://github.com/sidekiq-cron/sidekiq-cron/pull/337)
+- Fix `Sidekiq.options` deprecation warning (https://github.com/sidekiq-cron/sidekiq-cron/pull/338)
 
 ## 1.5.1
 
--  Fixes an issue that prevented the gem to work in previous Sidekiq versions (https://github.com/ondrejbartas/sidekiq-cron/pull/335)
+-  Fixes an issue that prevented the gem to work in previous Sidekiq versions (https://github.com/sidekiq-cron/sidekiq-cron/pull/335)
 
 ## 1.5.0
 
-- Integrate Sidekiq v6.5 breaking changes (https://github.com/ondrejbartas/sidekiq-cron/pull/331)
-- Add portuguese translations (https://github.com/ondrejbartas/sidekiq-cron/pull/332)
+- Integrate Sidekiq v6.5 breaking changes (https://github.com/sidekiq-cron/sidekiq-cron/pull/331)
+- Add portuguese translations (https://github.com/sidekiq-cron/sidekiq-cron/pull/332)
 
 ## 1.4.0
 
-- Fix buttons order in job show view (https://github.com/ondrejbartas/sidekiq-cron/pull/302)
-- Dark Mode support in UI (https://github.com/ondrejbartas/sidekiq-cron/pull/317/282)
-- Remove invocation of deprecated Redis functionality (https://github.com/ondrejbartas/sidekiq-cron/pull/318)
-- Internal code cleanup (https://github.com/ondrejbartas/sidekiq-cron/pull/317)
-- Optimize gem size (https://github.com/ondrejbartas/sidekiq-cron/pull/322)
-- Fix "Show All" button on cron jobs view with Sidekiq 6.3.0+ (https://github.com/ondrejbartas/sidekiq-cron/pull/321)
+- Fix buttons order in job show view (https://github.com/sidekiq-cron/sidekiq-cron/pull/302)
+- Dark Mode support in UI (https://github.com/sidekiq-cron/sidekiq-cron/pull/317/282)
+- Remove invocation of deprecated Redis functionality (https://github.com/sidekiq-cron/sidekiq-cron/pull/318)
+- Internal code cleanup (https://github.com/sidekiq-cron/sidekiq-cron/pull/317)
+- Optimize gem size (https://github.com/sidekiq-cron/sidekiq-cron/pull/322)
+- Fix "Show All" button on cron jobs view with Sidekiq 6.3.0+ (https://github.com/sidekiq-cron/sidekiq-cron/pull/321)
 - Documentation updates
 
 ## 1.3.0
@@ -48,12 +48,12 @@ All notable changes to this project will be documented in this file.
 - Fix deprecation warning for Redis 4.6.x
 - Fix different response from Redis#exists in different Redis versions
 - All PRs:
-  - https://github.com/ondrejbartas/sidekiq-cron/pull/275
-  - https://github.com/ondrejbartas/sidekiq-cron/pull/287
-  - https://github.com/ondrejbartas/sidekiq-cron/pull/309
-  - https://github.com/ondrejbartas/sidekiq-cron/pull/299
-  - https://github.com/ondrejbartas/sidekiq-cron/pull/314
-  - https://github.com/ondrejbartas/sidekiq-cron/pull/288
+  - https://github.com/sidekiq-cron/sidekiq-cron/pull/275
+  - https://github.com/sidekiq-cron/sidekiq-cron/pull/287
+  - https://github.com/sidekiq-cron/sidekiq-cron/pull/309
+  - https://github.com/sidekiq-cron/sidekiq-cron/pull/299
+  - https://github.com/sidekiq-cron/sidekiq-cron/pull/314
+  - https://github.com/sidekiq-cron/sidekiq-cron/pull/288
 
 ## 1.2.0
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Sidekiq-Cron
 
 [![Gem Version](https://badge.fury.io/rb/sidekiq-cron.svg)](https://badge.fury.io/rb/sidekiq-cron)
-[![Build Status](https://github.com/ondrejbartas/sidekiq-cron/workflows/CI/badge.svg?branch=master)](https://github.com/ondrejbartas/sidekiq-cron/actions)
+[![Build Status](https://github.com/sidekiq-cron/sidekiq-cron/workflows/CI/badge.svg?branch=master)](https://github.com/sidekiq-cron/sidekiq-cron/actions)
 [![Coverage Status](https://coveralls.io/repos/github/ondrejbartas/sidekiq-cron/badge.svg?branch=master)](https://coveralls.io/github/ondrejbartas/sidekiq-cron?branch=master)
 [![Join the chat at https://gitter.im/ondrejbartas/sidekiq-cron](https://badges.gitter.im/ondrejbartas/sidekiq-cron.svg)](https://gitter.im/ondrejbartas/sidekiq-cron?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
@@ -341,7 +341,7 @@ When running with many Sidekiq processes, the polling can add significant load t
 
 ## Contributing
 
-**Thanks to all [contributors](https://github.com/ondrejbartas/sidekiq-cron/graphs/contributors), you’re awesome and this wouldn’t be possible without you!**
+**Thanks to all [contributors](https://github.com/sidekiq-cron/sidekiq-cron/graphs/contributors), you’re awesome and this wouldn’t be possible without you!**
 
 * Check out the latest master to make sure the feature hasn't been implemented or the bug hasn't been fixed yet.
 * Check out the issue tracker to make sure someone already hasn't requested it and/or contributed it.

--- a/README.md
+++ b/README.md
@@ -241,10 +241,9 @@ second_job:
 
 There are multiple ways to load the jobs from a YAML file
 
-1. The gem will automatically load the jobs mentioned in `config/schedule.yml` file.
-2. When you want to load jobs from a different filename, mention the filename in sidekiq configuration,
-i.e. `cron_schedule_file: "config/users_schedule.yml"`
-3. Load the file manually as follows
+1. The gem will automatically load the jobs mentioned in `config/schedule.yml` file (it supports ERB)
+2. When you want to load jobs from a different filename, mention the filename in sidekiq configuration, i.e. `cron_schedule_file: "config/users_schedule.yml"`
+3. Load the file manually as follows:
 
 ```ruby
 # config/initializers/sidekiq.rb

--- a/sidekiq-cron.gemspec
+++ b/sidekiq-cron.gemspec
@@ -31,7 +31,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency("minitest", "~> 5.15")
   s.add_development_dependency("mocha", "~> 1.14")
-  s.add_development_dependency("redis-namespace", "~> 1.8")
   s.add_development_dependency("rack", "~> 2.2")
   s.add_development_dependency("rack-test", "~> 1.1")
   s.add_development_dependency("rake", "~> 13.0")

--- a/sidekiq-cron.gemspec
+++ b/sidekiq-cron.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.version = Sidekiq::Cron::VERSION
   s.summary = "Scheduler/Cron for Sidekiq jobs"
   s.description = "Enables to set jobs to be run in specified time (using CRON notation or natural language)"
-  s.homepage = "https://github.com/ondrejbartas/sidekiq-cron"
+  s.homepage = "https://github.com/sidekiq-cron/sidekiq-cron"
   s.authors = ["Ondrej Bartas"]
   s.email = "ondrej@bartas.cz"
   s.licenses = ["MIT"]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,31 +3,28 @@ ENV['RACK_ENV'] = 'test'
 
 require 'simplecov'
 SimpleCov.start do
-  add_filter "/test/"
-  add_group 'SidekiqCron', 'lib/'
+  add_filter "test/"
+  add_group 'Sidekiq-Cron', 'lib/'
 end
 
 require "minitest/autorun"
 require "rack/test"
 require 'mocha/minitest'
 require 'sidekiq'
-require "sidekiq-pro" if ENV['SIDEKIQ_PRO_VERSION']
 require 'sidekiq/web'
 require "sidekiq/cli"
-
-Sidekiq.logger.level = Logger::ERROR
-
-redis_url = ENV['REDIS_URL'] || 'redis://0.0.0.0:6379'
-REDIS = Sidekiq::RedisConnection.create(:url => redis_url, :namespace => 'testy')
-
-Sidekiq.configure_client do |config|
-  config.redis = { :url => redis_url, :namespace => 'testy' }
-end
-
 require 'sidekiq-cron'
 require 'sidekiq/cron/web'
 
-# For testing os symbilize args!
+redis_url = ENV['REDIS_URL'] || 'redis://0.0.0.0:6379'
+REDIS = Sidekiq::RedisConnection.create(:url => redis_url)
+
+Sidekiq.logger.level = Logger::ERROR
+Sidekiq.configure_client do |config|
+  config.redis = { :url => redis_url }
+end
+
+# For testing symbolize args
 class Hash
   def symbolize_keys
     transform_keys { |key| key.to_sym rescue key }


### PR DESCRIPTION
- some random simplications and typos in `test_helper.rb`
- remove development dep `redis-namespace`
- update links to new home (GH already supports automatic redirects for repo renames, but let's use the new link everywhere is possible)