### PR TITLE
fix argument error problem update from 1.6.0 to newer

### DIFF
--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -398,13 +398,12 @@ module Sidekiq
 
       # Export job data to hash.
       def to_hash
-        {
+        h = {
           name: @name,
           klass: @klass.to_s,
           cron: @cron,
           description: @description,
           args: @args.is_a?(String) ? @args : Sidekiq.dump_json(@args || []),
-          date_as_argument: date_as_argument? ? "1" : "0",
           message: @message.is_a?(String) ? @message : Sidekiq.dump_json(@message || {}),
           status: @status,
           active_job: @active_job ? "1" : "0",
@@ -413,6 +412,12 @@ module Sidekiq
           last_enqueue_time: @last_enqueue_time.to_s,
           symbolize_args: symbolize_args? ? "1" : "0",
         }
+
+        if date_as_argument?
+          h.merge!(date_as_argument: date_as_argument? ? "1" : "0")
+        end
+
+        h
       end
 
       def errors

--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -414,7 +414,7 @@ module Sidekiq
         }
 
         if date_as_argument?
-          h.merge!(date_as_argument: date_as_argument? ? "1" : "0")
+          h.merge!(date_as_argument: "1")
         end
 
         h

--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -398,7 +398,7 @@ module Sidekiq
 
       # Export job data to hash.
       def to_hash
-        h = {
+        hash = {
           name: @name,
           klass: @klass.to_s,
           cron: @cron,
@@ -414,10 +414,10 @@ module Sidekiq
         }
 
         if date_as_argument?
-          h.merge!(date_as_argument: "1")
+          hash.merge!(date_as_argument: "1")
         end
 
-        h
+        hash
       end
 
       def errors

--- a/test/unit/job_test.rb
+++ b/test/unit/job_test.rb
@@ -777,6 +777,58 @@ describe "Cron Job" do
     end
   end
 
+  # @note sidekiq-cron 1.6.0 cannot process options correctly if any date_as_argument evaluates to true.
+  # This has been tested to resolve issues in environments where multiple sidekiq-cron versions are running when updating from 1.6.0
+  # See https://github.com/sidekiq-cron/sidekiq-cron/issues/350#issuecomment-1409798837 for more information.
+  describe "compat with sidekiq cron 1.6.0" do
+    describe "#to_hash with date_as_argument false" do
+      before do
+        @args = {
+          name: "Test",
+          cron: "* * * * *",
+          klass: "CronTestClass",
+          date_as_argument: false,
+        }
+        @job = Sidekiq::Cron::Job.new(@args)
+      end
+
+      it "should not have date_as_argument property" do
+        assert !@job.to_hash.key?(:date_as_argument)
+      end
+    end
+
+    describe "#to_hash with no date_as_argument option" do
+      before do
+        @args = {
+          name: "Test",
+          cron: "* * * * *",
+          klass: "CronTestClass",
+        }
+        @job = Sidekiq::Cron::Job.new(@args)
+      end
+
+      it "should not have date_as_argument property" do
+        assert !@job.to_hash.key?(:date_as_argument)
+      end
+    end
+
+    describe "#to_hash with date_as_argument" do
+      before do
+        @args = {
+          name: "Test",
+          cron: "* * * * *",
+          klass: "CronTestClass",
+          date_as_argument: true,
+        }
+        @job = Sidekiq::Cron::Job.new(@args)
+      end
+
+      it "should have date_as_argument property with value '1'" do
+        assert_equal @job.to_hash[:date_as_argument], '1'
+      end
+    end
+  end
+
   describe "save" do
     before do
       @args = {


### PR DESCRIPTION
Fixed an error related to `date_as_argument` option that occurred when temporarily deploying multiple versions of sidekiq-cron.

This problem affects when you have a deployment where multiple versions of sidekiq-cron temporarily exist (such as [rolling update](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/deployment-type-ecs.html))

In this case, an option created in a newer version was unintentionally processed in the older version (1.6.0) and did not work correctly.

For more information, I have attempted to explain this at https://github.com/sidekiq-cron/sidekiq-cron/issues/350#issuecomment-1409798837

This PR avoids this problem by changing the hash of options created in the new version to work in the 1.6.0 version as well.

close: https://github.com/sidekiq-cron/sidekiq-cron/issues/350