### PR TITLE
feat: support serialize/deserialize by global_id of args

### DIFF
--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -2,6 +2,7 @@ require 'fugit'
 require 'sidekiq'
 require 'sidekiq/cron/support'
 require 'sidekiq/options'
+require 'globalid'
 
 module Sidekiq
   module Cron
@@ -14,6 +15,9 @@ module Sidekiq
 
       # Use the exists? method if we're on a newer version of Redis.
       REDIS_EXISTS_METHOD = Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new("7.0.0") || Gem.loaded_specs['redis'].version < Gem::Version.new('4.2') ? :exists : :exists?
+
+      # Use serialize/deserialize key of GlobalID.
+      GLOBALID_KEY = "_sc_globalid"
 
       # Crucial part of whole enqueuing job.
       def should_enque? time
@@ -85,7 +89,8 @@ module Sidekiq
       end
 
       def enqueue_args
-        date_as_argument? ? @args + [Time.now.to_f] : @args
+        args = date_as_argument? ? @args + [Time.now.to_f] : @args
+        deserialize_argument(args)
       end
 
       def enqueue_active_job(klass_const)
@@ -569,6 +574,8 @@ module Sidekiq
       # try to load JSON, then failover to string array.
       def parse_args(args)
         case args
+        when GlobalID::Identification
+          [convert_to_global_id_hash(args)]
         when String
           begin
             parsed_args = Sidekiq.load_json(args)
@@ -577,8 +584,10 @@ module Sidekiq
             [*args]
           end
         when Hash
+          args = serialize_argument(args)
           symbolize_args? ? [symbolize_args(args)] : [args]
         when Array
+          args = serialize_argument(args)
           symbolize_args? ? symbolize_args(args) : args
         else
           [*args]
@@ -652,6 +661,53 @@ module Sidekiq
       # Give Hash returns array for using it for redis.hmset
       def hash_to_redis hash
         hash.flat_map{ |key, value| [key, value || ""] }
+      end
+
+      def convert_to_global_id_hash(argument)
+        { GLOBALID_KEY => argument.to_global_id.to_s }
+      rescue URI::GID::MissingModelIdError
+        raise SerializationError, "Unable to serialize #{argument.class} " \
+          "without an id. (Maybe you forgot to call save?)"
+      end
+
+      def deserialize_argument(argument)
+        case argument
+        when String
+          argument
+        when Array
+          argument.map { |arg| deserialize_argument(arg) }
+        when Hash
+          if serialized_global_id?(argument)
+            deserialize_global_id argument
+          else
+            argument.transform_values { |v| deserialize_argument(v) }
+          end
+        else
+          argument
+        end
+      end
+
+      def serialized_global_id?(hash)
+        hash.size == 1 && hash.include?(GLOBALID_KEY)
+      end
+
+      def deserialize_global_id(hash)
+        GlobalID::Locator.locate hash[GLOBALID_KEY]
+      end
+
+      def serialize_argument(argument)
+        case argument
+        when GlobalID::Identification
+          convert_to_global_id_hash(argument)
+        when Array
+          argument.map { |arg| serialize_argument(arg) }
+        when Hash
+          argument.each_with_object({}) do |(key, value), hash|
+            hash[key] = serialize_argument(value)
+          end
+        else
+          argument
+        end
       end
     end
   end

--- a/sidekiq-cron.gemspec
+++ b/sidekiq-cron.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency("fugit", "~> 1.8")
   s.add_dependency("sidekiq", ">= 4.2.1")
+  s.add_dependency("globalid", "= 1.0.0")
 
   s.add_development_dependency("minitest", "~> 5.15")
   s.add_development_dependency("mocha", "~> 1.14")

--- a/test/models/person.rb
+++ b/test/models/person.rb
@@ -1,0 +1,21 @@
+class Person
+  include GlobalID::Identification
+
+  attr_reader :id
+
+  def self.find(id)
+    new(id)
+  end
+
+  def initialize(id)
+    @id = id
+  end
+
+  def to_global_id(options = {})
+    super app: "app"
+  end
+
+  def ==(other_person)
+    other_person.is_a?(Person) && id.to_s == other_person.id.to_s
+  end
+end

--- a/test/unit/job_test.rb
+++ b/test/unit/job_test.rb
@@ -1,4 +1,5 @@
 require './test/test_helper'
+require "./test/models/person"
 
 describe "Cron Job" do
   before do
@@ -336,6 +337,45 @@ describe "Cron Job" do
         assert_equal args[0], {foo: 'bar'}
         assert args[-1].is_a?(Float)
         assert args[-1].between?(Time.now.to_f - 1, Time.now.to_f)
+      end
+    end
+
+    describe 'with GlobalID::Identification args' do      
+      before do
+        @args.merge!(args: Person.new(1))
+        @job = Sidekiq::Cron::Job.new(@args)
+      end
+
+      let(:args) { @job.sidekiq_worker_message['args'] }
+
+      it 'should add timestamp to args' do
+        assert_equal args[0], Person.new(1)
+      end
+    end
+
+    describe 'with GlobalID::Identification args in Array' do      
+      before do
+        @args.merge!(args: [Person.new(1)])
+        @job = Sidekiq::Cron::Job.new(@args)
+      end
+
+      let(:args) { @job.sidekiq_worker_message['args'] }
+
+      it 'should add timestamp to args' do
+        assert_equal args[0], Person.new(1)
+      end
+    end
+
+    describe 'with GlobalID::Identification args in Hash' do      
+      before do
+        @args.merge!(args: {person: Person.new(1)})
+        @job = Sidekiq::Cron::Job.new(@args)
+      end
+
+      let(:args) { @job.sidekiq_worker_message['args'] }
+
+      it 'should add timestamp to args' do
+        assert_equal args[0], {person: Person.new(1)}
       end
     end
   end
@@ -916,6 +956,42 @@ describe "Cron Job" do
       Sidekiq::Cron::Job.new(args).tap do |job|
         assert_equal job.args, ["This is array"]
         assert_equal job.name, "Test"
+      end
+    end
+
+    it "from GlobalID::Identification" do
+      args = {
+        name: "Test",
+        cron: "* * * * *",
+        klass: "CronTestClass",
+        args: Person.new(1)
+      }
+      Sidekiq::Cron::Job.new(args).tap do |job|
+        assert_equal job.args, [{"_sc_globalid"=>"gid://app/Person/1"}]
+      end
+    end
+
+    it "from GlobalID::Identification in Array" do
+      args = {
+        name: "Test",
+        cron: "* * * * *",
+        klass: "CronTestClass",
+        args: [Person.new(1)]
+      }
+      Sidekiq::Cron::Job.new(args).tap do |job|
+        assert_equal job.args, [{"_sc_globalid"=>"gid://app/Person/1"}]
+      end
+    end
+
+    it "from GlobalID::Identification in Hash" do
+      args = {
+        name: "Test",
+        cron: "* * * * *",
+        klass: "CronTestClass",
+        args: {person: Person.new(1)}
+      }
+      Sidekiq::Cron::Job.new(args).tap do |job|
+        assert_equal job.args, [{person: {"_sc_globalid"=>"gid://app/Person/1"}}]
       end
     end
   end


### PR DESCRIPTION
Added support for ActiveRecord serialize/deserialize using GlobalID for Sidekiq::Cron::Job arguments.
https://guides.rubyonrails.org/active_job_basics.html#globalid

e.g. Use Person model as a arguments of Sidekiq::Cron::Job

```rb
class Person < ApplicationRecord
end

class ExampleJob < ActiveJob::Base
  queue_as :default

  def perform(person)
    puts person
  end
end


person = Person.create(id: 1)
Sidekiq::Cron::Job.create(name: 'Example', cron: '*/1 * * * *', class: 'ExampleJob', args: person)
Sidekiq::Cron::Job.create(name: 'Example', cron: '*/1 * * * *', class: 'ExampleJob', args: [person]) 
```

ref:
- https://github.com/rails/rails/blob/v7.0.4/activejob/lib/active_job/arguments.rb