### PR TITLE
Allow for keyword args in Poller

### DIFF
--- a/lib/sidekiq/cron/launcher.rb
+++ b/lib/sidekiq/cron/launcher.rb
@@ -14,7 +14,7 @@ module Sidekiq
       attr_reader :cron_poller
 
       # Add cron poller and execute normal initialize of Sidekiq launcher.
-      def initialize(config)
+      def initialize(config, **kwargs)
         config[:cron_poll_interval] = DEFAULT_POLL_INTERVAL if config[:cron_poll_interval].nil?
 
         @cron_poller = Sidekiq::Cron::Poller.new(config) if config[:cron_poll_interval] > 0


### PR DESCRIPTION
Formerly, `Sidekiq::Launcher.new` took one "config" argument. As of v7 there's a possibility of  "embedded" being passed in. ex: `Sidekiq::Launcher.new(config, embedded: true)`

Presently, when running sidekiq-cron with embedded mode, we get an exception. To reproduce this, load sidekiq-cron with Sidekiq in "[embedded mode](https://www.mikeperham.com/2022/10/27/sidekiq-7.0-embedding/)"

This PR adds optional keyword args to pass along, to support `embedded` and to allow for future keyword args that might get added.

