### PR TITLE
[CI] Allow to test different Sidekiq versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,14 +20,15 @@ jobs:
           --health-retries 5
         ports:
           - 6379:6379
+    env:
+      SIDEKIQ_VERSION: "${{ matrix.sidekiq }}"
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
+
       with:
         bundler-cache: true # 'bundle install' and cache gems
         ruby-version: ${{ matrix.ruby }}
     - name: Run tests
-      env:
-        SIDEKIQ_VERSION: "${{ matrix.sidekiq }}"
       run: bundle exec rake test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", ruby-head]
+        ruby: ["2.7", "3.0", "3.1", "3.2", "ruby-head"]
+        sidekiq: ["~> 6", "~> 7"]
     services:
       redis:
         image: redis
@@ -27,4 +28,6 @@ jobs:
         bundler-cache: true # 'bundle install' and cache gems
         ruby-version: ${{ matrix.ruby }}
     - name: Run tests
+      env:
+        SIDEKIQ_VERSION: "${{ matrix.sidekiq }}"
       run: bundle exec rake test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,6 @@ jobs:
     - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
-
       with:
         bundler-cache: true # 'bundle install' and cache gems
         ruby-version: ${{ matrix.ruby }}

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,6 @@
 source 'https://rubygems.org'
 
 gemspec
+
+# To test different Sidekiq versions
+gem "sidekiq", ENV.fetch("SIDEKIQ_VERSION", ">= 6")

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gemspec
-
 # To test different Sidekiq versions
 gem "sidekiq", ENV.fetch("SIDEKIQ_VERSION", ">= 6")
+
+gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
+gemspec
+
 # To test different Sidekiq versions
 gem "sidekiq", ENV.fetch("SIDEKIQ_VERSION", ">= 6")
-
-gemspec

--- a/README.md
+++ b/README.md
@@ -26,12 +26,6 @@ Before upgrading to a new version, please read our [Changelog](CHANGELOG.md).
 
 ## Installation
 
-### Requirements
-
-- Redis 2.8 or greater is required (Redis 3.0.3 or greater is recommended for large scale use)
-- Sidekiq 4.2 or greater is required (for Sidekiq < 4 use version sidekiq-cron 0.3.1)
-- Sidekiq 6.5 requires Sidekiq-Cron 1.5+
-
 Install the gem:
 
 ```

--- a/sidekiq-cron.gemspec
+++ b/sidekiq-cron.gemspec
@@ -24,10 +24,10 @@ Gem::Specification.new do |s|
     "sidekiq-cron.gemspec",
   ]
 
-  s.required_ruby_version = ">= 2.6"
+  s.required_ruby_version = ">= 2.7"
 
   s.add_dependency("fugit", "~> 1.8")
-  s.add_dependency("sidekiq", ">= 4.2.1")
+  s.add_dependency("sidekiq", ">= 6")
 
   s.add_development_dependency("minitest", "~> 5.15")
   s.add_development_dependency("mocha", "~> 1.14")


### PR DESCRIPTION
Closes #380

Also, remove Ruby 2.6 support. This version is pretty EOL, so time to stick to 2.7 as the minimal.