### PR TITLE
[deps] upgrade required globalid version to fix a potential security vulnerability

### DIFF
--- a/sidekiq-cron.gemspec
+++ b/sidekiq-cron.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency("fugit", "~> 1.8")
   s.add_dependency("sidekiq", ">= 6")
-  s.add_dependency("globalid", "= 1.0.0")
+  s.add_dependency("globalid", ">= 1.0.1")
 
   s.add_development_dependency("minitest", "~> 5.15")
   s.add_development_dependency("mocha", "~> 1.14")


### PR DESCRIPTION
See: https://github.com/advisories/GHSA-23c2-gwp5-pxw9

@nyuta01 I just received a 🤖 dependabot warning due to that version.
