### PR TITLE
Add the ability to deactivate the default schedule loader

### DIFF
--- a/lib/sidekiq/cron.rb
+++ b/lib/sidekiq/cron.rb
@@ -5,5 +5,8 @@ require "sidekiq/cron/schedule_loader"
 
 module Sidekiq
   module Cron
+    def self.enabled_schedule_loader?
+      Sidekiq::Options.fetch(:enable_default_cron_schedule, true) == true
+    end
   end
 end

--- a/lib/sidekiq/cron/schedule_loader.rb
+++ b/lib/sidekiq/cron/schedule_loader.rb
@@ -2,13 +2,14 @@ require 'sidekiq'
 require 'sidekiq/cron/job'
 require 'sidekiq/options'
 
-if Sidekiq.server?
+if Sidekiq.server? && Sidekiq::Cron.enabled_schedule_loader?
   Sidekiq.configure_server do |config|
     schedule_file = Sidekiq::Options[:cron_schedule_file] || 'config/schedule.yml'
 
     if File.exist?(schedule_file)
       config.on(:startup) do
         schedule = Sidekiq::Cron::Support.load_yaml(ERB.new(IO.read(schedule_file)).result)
+
         if schedule.kind_of?(Hash)
           Sidekiq::Cron::Job.load_from_hash! schedule
         elsif schedule.kind_of?(Array)

--- a/lib/sidekiq/options.rb
+++ b/lib/sidekiq/options.rb
@@ -2,12 +2,16 @@ require 'sidekiq'
 
 module Sidekiq
   module Options
+    def self.config
+      options_field ? Sidekiq.public_send(options_field) : Sidekiq
+    end
+
     def self.[](key)
-      options_field ? Sidekiq.public_send(options_field)[key] : Sidekiq[key]
+      config[key]
     end
 
     def self.[]=(key, value)
-      options_field ? Sidekiq.public_send(options_field)[key] = value : Sidekiq[key] = value
+      config[key] = value
     end
 
     def self.options_field
@@ -20,6 +24,10 @@ module Sidekiq
       else
         :options
       end
+    end
+
+    def self.fetch(*args, &block)
+      config.fetch(*args, &block)
     end
   end
 end


### PR DESCRIPTION
Hello and thank you for this awesome library!

I drafted this PR because I'm having some troubles with my current sidekiq cron configuration and I hope it would be useful to someone else.

In the application I'm working in, I have many yaml schedule files (divided by application domain). 
But the current [schedule_loader](https://github.com/sidekiq-cron/sidekiq-cron/blob/master/lib/sidekiq/cron/schedule_loader.rb#L13) is deleting all previously configured jobs, keeping the only configurations inside the default `config/schedule.yml`file. 

NOTE: I simply load multiple yaml files inside the sidekiq initializer, as reported by the README:

<img width="893" alt="Screenshot 2023-04-26 at 11 40 48" src="https://user-images.githubusercontent.com/56606/234536659-b849a491-e3a7-436f-a745-aa77532be68e.png">

---

In my option the easiest way to handle this use-case, would be to [remove the automatic initialization of the schedule_loader](https://github.com/sidekiq-cron/sidekiq-cron/blob/master/lib/sidekiq/cron.rb#L4) and allow the user to manually require it inside its own sidekiq initializer:

```
# config/initializers/sidekiq.rb
require "sidekiq"
require "sidekiq/cron"
require "sidekiq/cron/schedule_loader" # optional
```

But this would mean to introduce a potential breaking change in the next release..

So, I drafted this PR to introduce a new configuration `enable_default_cron_scheduler` to enable/disable the schedule_loader initialization, by simply configure the application sidekiq.yml file.

Le me know you think, so that I could possibly improve this PR or just close it 😄 


