### PR TITLE
Avoid confusion about `queue_name_delimitrer` default value on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ gem "sidekiq-cron"
   'date_as_argument' => true, # add the time of execution as last argument of the perform method
   'active_job' => true,  # enqueue job through Rails 4.2+ Active Job interface
   'queue_name_prefix' => 'prefix', # Rails 4.2+ Active Job queue with prefix
-  'queue_name_delimiter' => '.', # Rails 4.2+ Active Job queue with custom delimiter
+  'queue_name_delimiter' => '.', # Rails 4.2+ Active Job queue with custom delimiter (default: '_')
   'description' => 'A sentence describing what work this job performs'
   'status' => 'disabled' # default: enabled
 }


### PR DESCRIPTION
I believe describing the default value of `queue_name_delimitrer` should reduce confusion when users read the document.

https://github.com/sidekiq-cron/sidekiq-cron/blob/7cc3d13150e7fecce6b2f71d3c86a640e9ae6436/lib/sidekiq/cron/job.rb#L119