### PR TITLE
Reduce gem size by excluding test files

### DIFF
--- a/sidekiq-cron.gemspec
+++ b/sidekiq-cron.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
     "LICENSE.txt",
     "README.md"
   ]
-  s.files = Dir.glob('lib/**/*') + Dir.glob('test/**/*') + [
+  s.files = Dir.glob('lib/**/*') + [
     "CHANGELOG.md",
     "Gemfile",
     "LICENSE.txt",


### PR DESCRIPTION
```console
$ gem build -o before

$ git switch reduce-gem-size

$ git build -o after

$ du -sh before after
 32K	before
 24K	after
```

=> **-8K** saved