### PR TITLE
remove Sidekiq.server? check from schedule loader

### DIFF
--- a/lib/sidekiq/cron/schedule_loader.rb
+++ b/lib/sidekiq/cron/schedule_loader.rb
@@ -2,20 +2,18 @@ require 'sidekiq'
 require 'sidekiq/cron/job'
 require 'sidekiq/options'
 
-if Sidekiq.server?
-  Sidekiq.configure_server do |config|
-    schedule_file = Sidekiq::Options[:cron_schedule_file] || 'config/schedule.yml'
+Sidekiq.configure_server do |config|
+  schedule_file = Sidekiq::Options[:cron_schedule_file] || 'config/schedule.yml'
 
-    if File.exist?(schedule_file)
-      config.on(:startup) do
-        schedule = Sidekiq::Cron::Support.load_yaml(ERB.new(IO.read(schedule_file)).result)
-        if schedule.kind_of?(Hash)
-          Sidekiq::Cron::Job.load_from_hash!(schedule, source: "schedule")
-        elsif schedule.kind_of?(Array)
-          Sidekiq::Cron::Job.load_from_array!(schedule, source: "schedule")
-        else
-          raise "Not supported schedule format. Confirm your #{schedule_file}"
-        end
+  if File.exist?(schedule_file)
+    config.on(:startup) do
+      schedule = Sidekiq::Cron::Support.load_yaml(ERB.new(IO.read(schedule_file)).result)
+      if schedule.kind_of?(Hash)
+        Sidekiq::Cron::Job.load_from_hash!(schedule, source: "schedule")
+      elsif schedule.kind_of?(Array)
+        Sidekiq::Cron::Job.load_from_array!(schedule, source: "schedule")
+      else
+        raise "Not supported schedule format. Confirm your #{schedule_file}"
       end
     end
   end


### PR DESCRIPTION
Starting with 7.0, Sidekiq can be run in embedded mode where `Sidekiq.server?` returns `false`

Reference: https://www.mikeperham.com/2022/10/27/sidekiq-7.0-embedding/