### PR TITLE
Fix tests failing in Sidekiq 6

### DIFF
--- a/lib/sidekiq/options.rb
+++ b/lib/sidekiq/options.rb
@@ -3,11 +3,15 @@ require 'sidekiq'
 module Sidekiq
   module Options
     def self.[](key)
-      options_field ? Sidekiq.public_send(options_field)[key] : Sidekiq[key]
+      self.config[key]
     end
 
     def self.[]=(key, value)
-      options_field ? Sidekiq.public_send(options_field)[key] = value : Sidekiq[key] = value
+      self.config[key] = value
+    end
+
+    def self.config
+      options_field ? Sidekiq.public_send(options_field) : Sidekiq
     end
 
     def self.options_field

--- a/test/unit/launcher_test.rb
+++ b/test/unit/launcher_test.rb
@@ -11,7 +11,7 @@ describe 'Cron launcher' do
         assert_equal Sidekiq::Cron::Launcher::DEFAULT_POLL_INTERVAL, options[:cron_poll_interval]
       end
 
-      Sidekiq::Launcher.new(Sidekiq.respond_to?(:default_configuration) ? Sidekiq.default_configuration : Sidekiq)
+      Sidekiq::Launcher.new(Sidekiq::Options.config)
     end
 
     it 'initializes poller with the configured poll interval' do
@@ -20,14 +20,14 @@ describe 'Cron launcher' do
       end
 
       Sidekiq::Options[:cron_poll_interval] = 99
-      Sidekiq::Launcher.new(Sidekiq.respond_to?(:default_configuration) ? Sidekiq.default_configuration : Sidekiq)
+      Sidekiq::Launcher.new(Sidekiq::Options.config)
     end
 
     it 'does not initialize the poller when interval is 0' do
       Sidekiq::Cron::Poller.expects(:new).never
 
       Sidekiq::Options[:cron_poll_interval] = 0
-      Sidekiq::Launcher.new(Sidekiq.respond_to?(:default_configuration) ? Sidekiq.default_configuration : Sidekiq)
+      Sidekiq::Launcher.new(Sidekiq::Options.config)
     end
   end
 end


### PR DESCRIPTION
`SIDEKIQ_VERSION=6 bundle exec rake test` was previously failing since `Sidekiq` doesn't have options:

```
  1) Error:
Cron launcher::initialization#test_0001_initializes poller with default poll interval when not configured:
NoMethodError: undefined method `[]' for Sidekiq:Module

        config[:cron_poll_interval] = DEFAULT_POLL_INTERVAL if config[:cron_poll_interval].nil?
                                                                     ^^^^^^^^^^^^^^^^^^^^^
    /Users/stanhu/github/sidekiq-cron/lib/sidekiq/cron/launcher.rb:20:in `initialize'
    /Users/stanhu/github/sidekiq-cron/test/unit/launcher_test.rb:14:in `new'
    /Users/stanhu/github/sidekiq-cron/test/unit/launcher_test.rb:14:in `block (3 levels) in <top (required)>'

  2) Error:
Cron launcher::initialization#test_0003_does not initialize the poller when interval is 0:
NoMethodError: undefined method `[]' for Sidekiq:Module

        config[:cron_poll_interval] = DEFAULT_POLL_INTERVAL if config[:cron_poll_interval].nil?
                                                                     ^^^^^^^^^^^^^^^^^^^^^
    /Users/stanhu/github/sidekiq-cron/lib/sidekiq/cron/launcher.rb:20:in `initialize'
    /Users/stanhu/github/sidekiq-cron/test/unit/launcher_test.rb:30:in `new'
    /Users/stanhu/github/sidekiq-cron/test/unit/launcher_test.rb:30:in `block (3 levels) in <top (required)>'

  3) Error:
Cron launcher::initialization#test_0002_initializes poller with the configured poll interval:
NoMethodError: undefined method `[]' for Sidekiq:Module

        config[:cron_poll_interval] = DEFAULT_POLL_INTERVAL if config[:cron_poll_interval].nil?
                                                                     ^^^^^^^^^^^^^^^^^^^^^
    /Users/stanhu/github/sidekiq-cron/lib/sidekiq/cron/launcher.rb:20:in `initialize'
    /Users/stanhu/github/sidekiq-cron/test/unit/launcher_test.rb:23:in `new'
    /Users/stanhu/github/sidekiq-cron/test/unit/launcher_test.rb:23:in `block (3 levels) in <top (required)>'
```