### PR TITLE
feat: human readable UI

### DIFF
--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -1,4 +1,5 @@
 require 'fugit'
+require 'cronex'
 require 'globalid'
 require 'sidekiq'
 require 'sidekiq/cron/support'
@@ -368,6 +369,12 @@ module Sidekiq
         JSON.pretty_generate Sidekiq.load_json(message)
       rescue JSON::ParserError
         message
+      end
+
+      def human_cron
+        Cronex::ExpressionDescriptor.new(cron).description
+      rescue => e
+        cron
       end
 
       def status_from_redis

--- a/lib/sidekiq/cron/views/cron.erb
+++ b/lib/sidekiq/cron/views/cron.erb
@@ -41,7 +41,7 @@
         <tr>
           <td style="<%= style %>"><%= t job.status %></td>
           <td style="<%= style %>">
-            <a href="<%= root_path %>cron/<%= CGI.escape(job.name).gsub('+', '%20') %>">
+            <a href="<%= root_path %>cron/<%= CGI.escape(job.name).gsub('+', '%20') %>" title="<%= job.description %>">
               <b style="<%= style %>"><%= job.name %></b>
             </a>
             <hr style="margin:3px;border:0;">
@@ -61,7 +61,7 @@
             <% end %>
             </small>
           </td>
-          <td style="<%= style %>"><b><%= job.cron.gsub(" ", "&nbsp;") %></b></td>
+          <td style="<%= style %>"><b><%= job.human_cron %><br/><small><%= job.cron.gsub(" ", "&nbsp;") %></small></b></td>
           <td style="<%= style %>"><%= job.last_enqueue_time ? relative_time(job.last_enqueue_time) : "-" %></td>
           <td style="<%= style %>">
             <% if job.status == 'enabled' %>

--- a/sidekiq-cron.gemspec
+++ b/sidekiq-cron.gemspec
@@ -26,9 +26,10 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.7"
 
+  s.add_dependency("cronex", ">= 0.13.0")
   s.add_dependency("fugit", "~> 1.8")
-  s.add_dependency("sidekiq", ">= 6")
   s.add_dependency("globalid", ">= 1.0.1")
+  s.add_dependency("sidekiq", ">= 6")
 
   s.add_development_dependency("minitest", "~> 5.15")
   s.add_development_dependency("mocha", "~> 2.1")


### PR DESCRIPTION
This changes the UI to be more human readable, using the [cronex](https://github.com/alpinweis/cronex) library to generate a human version of each job's cron. It also sets the `title` property of the job's name to the description, so that you're able to hover over the job and see the description without clicking into the show page.

<img width="1164" alt="Screen Shot 2023-12-13 at 8 21 40 AM" src="https://github.com/sidekiq-cron/sidekiq-cron/assets/1231554/c3b8e01f-2fee-4c57-a2f9-93af53cd5bc5">
