### PR TITLE
Add warning log when 'symbolize_args: true' is used without 'active_job: true'

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ class HardWorker
 end
 ```
 
+For Sidekiq workers, `symbolize_args: true` in `Sidekiq::Cron::Job.create` or in Hash configuration is gonna be ignored as Sidekiq currently only allows for [simple JSON datatypes](https://github.com/sidekiq/sidekiq/wiki/The-Basics#:~:text=These%20two%20methods,not%20serialize%20properly.).
+
 #### Active Job Worker
 
 You can schedule `ExampleJob` which looks like:

--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -313,6 +313,9 @@ module Sidekiq
         @active_job_queue_name_prefix = args["queue_name_prefix"]
         @active_job_queue_name_delimiter = args["queue_name_delimiter"]
 
+        # symbolize_args is only used when active_job is true
+        Sidekiq.logger.warn { "Cron Jobs - 'symbolize_args' is gonna be ignored, as it is only used when 'active_job' is true" } if @symbolize_args && !@active_job
+
         if args["message"]
           @message = args["message"]
           message_data = Sidekiq.load_json(@message) || {}


### PR DESCRIPTION
Relates to this [issue](https://github.com/sidekiq-cron/sidekiq-cron/issues/443)

- Logs a warning when we use `symbolize_args: true` without using `active_job: true`.
- Adds this specifity in the README.