### PR TITLE
Fix: unused variable warning

### DIFF
--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -777,7 +777,7 @@ module Sidekiq
       def get_job_class_options(klass)
         klass = klass.is_a?(Class) ? klass : begin
           Sidekiq::Cron::Support.constantize(klass)
-        rescue Exception => e
+        rescue Exception
           # noop
         end
 

--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -777,7 +777,7 @@ module Sidekiq
       def get_job_class_options(klass)
         klass = klass.is_a?(Class) ? klass : begin
           Sidekiq::Cron::Support.constantize(klass)
-        rescue Exception
+        rescue NameError
           # noop
         end
 


### PR DESCRIPTION
Fixes unused variable warning in rescue when running specs.

<img width="1512" alt="Screenshot 2024-02-23 at 4 40 29 PM" src="https://github.com/sidekiq-cron/sidekiq-cron/assets/31462903/23354a00-7328-4d71-9774-4e8171f5f1ab">
