### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,6 @@ All notable changes to this project will be documented in this file.
 
 ## 0.3.0
 
-- Suport for Active Job
+- Support for Active Job
 - Sidekiq cron web ui needs to be loaded by: require 'sidekiq/cron/web'
 - Add load_from_hash! and load_from_array! which cleanup jobs before adding new ones

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ end
 
 #### Usage
 
-When creating a new job, you can optionaly give a `namespace` attribute, and then you can pass it too in the `find` or `destroy` methods.
+When creating a new job, you can optionally give a `namespace` attribute, and then you can pass it too in the `find` or `destroy` methods.
 
 ```ruby
 Sidekiq::Cron::Job.create(
@@ -131,7 +131,7 @@ Sidekiq::Cron::Job.create(
 )
 # INFO: Cron Jobs - add job with name Hard worker - every 5min in the namespace Foo
 
-# Without specifing the namespace, Sidekiq::Cron use the `default` one, therefore `count` return 0.
+# Without specifying the namespace, Sidekiq::Cron use the `default` one, therefore `count` return 0.
 Sidekiq::Cron::Job.count
 #=> 0
 

--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -10,7 +10,7 @@ require 'sidekiq/options'
 module Sidekiq
   module Cron
     class Job
-      # How long we would like to store informations about previous enqueues.
+      # How long we would like to store information about previous enqueues.
       REMEMBER_THRESHOLD = 24 * 60 * 60
 
       # Time format for enqueued jobs.
@@ -331,7 +331,7 @@ module Sidekiq
           klass_data = get_job_class_options(@klass)
           message_data = klass_data.merge(message_data)
 
-          # Override queue if setted in config,
+          # Override queue if set in config,
           # only if message is hash - can be string (dumped JSON).
           if args['queue']
             @queue = message_data['queue'] = args['queue']
@@ -481,7 +481,7 @@ module Sidekiq
           # Add to set of all jobs
           conn.sadd self.class.jobs_key(@namespace), [redis_key]
 
-          # Add informations for this job!
+          # Add information for this job!
           conn.hset redis_key, to_hash.transform_values! { |v| v || '' }
 
           # Add information about last time! - don't enque right after scheduler poller starts!
@@ -519,7 +519,7 @@ module Sidekiq
           # Delete from set.
           conn.srem self.class.jobs_key(@namespace), [redis_key]
 
-          # Delete runned timestamps.
+          # Delete ran timestamps.
           conn.del job_enqueued_key
 
           # Delete jid_history.

--- a/lib/sidekiq/cron/launcher.rb
+++ b/lib/sidekiq/cron/launcher.rb
@@ -1,7 +1,7 @@
 require 'sidekiq/cron/poller'
 
 # For Cron we need to add some methods to Launcher
-# so look at the code bellow.
+# so look at the code below.
 #
 # We are creating new cron poller instance and
 # adding start and stop commands to launcher.

--- a/lib/sidekiq/cron/poller.rb
+++ b/lib/sidekiq/cron/poller.rb
@@ -7,7 +7,7 @@ require 'sidekiq/options'
 
 module Sidekiq
   module Cron
-    # The Poller checks Redis every N seconds for sheduled cron jobs.
+    # The Poller checks Redis every N seconds for scheduled cron jobs.
     class Poller < Sidekiq::Scheduled::Poller
       def initialize(config = nil)
         if Gem::Version.new(Sidekiq::VERSION) < Gem::Version.new('6.5.0')

--- a/test/unit/job_test.rb
+++ b/test/unit/job_test.rb
@@ -71,7 +71,7 @@ describe "Cron Job" do
       assert @job.respond_to?(:disabled?)
     end
 
-    it 'have sort_name - used for sorting enabled disbaled jobs on frontend' do
+    it 'have sort_name - used for sorting enabled disabled jobs on frontend' do
       job = Sidekiq::Cron::Job.new(name: "TestName")
       assert_equal job.sort_name, "0_testname"
     end
@@ -119,7 +119,7 @@ describe "Cron Job" do
       @job = Sidekiq::Cron::Job.new(@args)
     end
 
-    it "have all setted attributes" do
+    it "have all set attributes" do
       @args.each do |key, value|
         assert_equal @job.send(key), value, "New job should have #{key} with value #{value} but it has: #{@job.send(key)}"
       end


### PR DESCRIPTION
Found via `codespell -L enque,sie`