### PR TITLE
Readme: clarify that job status gets persisted

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ gem "sidekiq-cron"
 }
 ```
 
+**NOTE** The `status` of a job does not get changed in Redis when a job gets reloaded unless the `status` property is explicitly set.
+
 ### Time, cron and Sidekiq-Cron
 
 For testing your cron notation you can use [crontab.guru](https://crontab.guru).


### PR DESCRIPTION
It was not obvious from the docs that this field got persisted when a job gets reloaded if it isn't set explicitly. That means that a job that is disabled in the web UI would still be disabled after a redeployment. This just adds some more documentation to make that abundantly clear.