### PR TITLE
sidekiq/cron/job: allows symbol keys in .load_from_array!

### DIFF
--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -212,7 +212,7 @@ module Sidekiq
       # Like #load_from_array.
       # If exists old jobs in Redis but removed from args, destroy old jobs.
       def self.load_from_array!(array, options = {})
-        job_names = array.map { |job| job["name"] }
+        job_names = array.map { |job| job["name"] || job[:name] }
         destroy_removed_jobs(job_names)
         load_from_array(array, options)
       end


### PR DESCRIPTION
This was not persisting the last enqueued at time when the cron schedule got reloaded during redeployments because it expected all job names to be found at the string key `"name"` instead of the symbol key `:name`. Now symbols keys should work here too.