### PR TITLE
Add strict cron parsing mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,29 @@ Sidekiq::Options[:cron_poll_interval] = 10
 
 The default value at time of writing is 30 seconds. See [under the hood](#under-the-hood) for more details.
 
+#### Strict Cron Parsing
+
+Enable stricter parsing for natural language cron strings.
+
+By default natural language cron string parsing is permissive. If a natural language cron string would create multiple cron lines, it will use the first one and ignore the rest. Strict parsing will throw an error in that case.
+
+Ex. `every day at 3:15 and 4:30`
+
+Before:
+- Equivalent to `15 3 * * *`.
+- `30 4 * * *` gets ignored.
+
+After:
+- Throws an error.
+
+This can be enabled in the configuration settings:
+
+```ruby
+Sidekiq::Cron.configure do |config|
+  config.strict_cron_parsing!
+end
+```
+
 ### Namespacing
 
 #### Default namespace

--- a/README.md
+++ b/README.md
@@ -88,6 +88,38 @@ Since sidekiq-cron `v1.7.0`, you can use the natural-language formats supported 
 
 See [the relevant part of Fugit documentation](https://github.com/floraison/fugit#fugitnat) for details.
 
+There are multiple modes that determine how natural-language cron strings will be parsed.
+
+1. `:single` (default)
+
+```ruby
+Sidekiq::Cron.configure do |config|
+  # Note: This doesn't need to be specified since it's the default.
+  config.natural_language_parsing_mode = :single
+end
+```
+
+This parses the first possible cron line from the given string and then ignores any additional cron lines.
+
+Ex. `every day at 3:15 and 4:30`
+
+- Equivalent to `15 3 * * *`.
+- `30 4 * * *` gets ignored.
+
+2. `:strict`
+
+```ruby
+Sidekiq::Cron.configure do |config|
+  config.natural_language_parsing_mode = :strict
+end
+```
+
+This throws an error if the given string would be parsed into multiple cron lines.
+
+Ex. `every day at 3:15 and 4:30`
+
+- Would throw an error and the associated cron job would be invalid
+
 #### Second-precision (sub-minute) cronlines
 
 In addition to the standard 5-parameter cronline format, sidekiq-cron supports scheduling jobs with second-precision using a modified 6-parameter cronline format:
@@ -103,29 +135,6 @@ Sidekiq::Options[:cron_poll_interval] = 10
 ```
 
 The default value at time of writing is 30 seconds. See [under the hood](#under-the-hood) for more details.
-
-#### Strict Cron Parsing
-
-Enable stricter parsing for natural language cron strings.
-
-By default natural language cron string parsing is permissive. If a natural language cron string would create multiple cron lines, it will use the first one and ignore the rest. Strict parsing will throw an error in that case.
-
-Ex. `every day at 3:15 and 4:30`
-
-Before:
-- Equivalent to `15 3 * * *`.
-- `30 4 * * *` gets ignored.
-
-After:
-- Throws an error.
-
-This can be enabled in the configuration settings:
-
-```ruby
-Sidekiq::Cron.configure do |config|
-  config.strict_cron_parsing!
-end
-```
 
 ### Namespacing
 

--- a/lib/sidekiq/cron.rb
+++ b/lib/sidekiq/cron.rb
@@ -21,6 +21,19 @@ module Sidekiq
 
       def initialize
         @default_namespace = 'default'
+        @strict_cron_parsing = false
+      end
+
+      # Throws an error when a natural language cron string would get
+      # parsed into multiple cron lines. By default the `fugit` gem is
+      # permissive when parsing natural language cron strings. Only the first
+      # cron line is used in that case and all other ones are ignored.
+      def strict_cron_parsing!
+        @strict_cron_parsing = true
+      end
+
+      def strict_cron_parsing?
+        @strict_cron_parsing
       end
     end
   end

--- a/lib/sidekiq/cron.rb
+++ b/lib/sidekiq/cron.rb
@@ -19,21 +19,23 @@ module Sidekiq
       # The default namespace is used when no namespace is specified.
       attr_accessor :default_namespace
 
+      # The parsing mode when using the natural language cron syntax from the `fugit` gem.
+      #
+      # :single -- use the first parsed cron line and ignore the rest (default)
+      # :strict -- raise an error if multiple cron lines are parsed from one string
+      attr_reader :natural_cron_parsing_mode
+
       def initialize
         @default_namespace = 'default'
-        @strict_cron_parsing = false
+        @natural_cron_parsing_mode = :single
       end
 
-      # Throws an error when a natural language cron string would get
-      # parsed into multiple cron lines. By default the `fugit` gem is
-      # permissive when parsing natural language cron strings. Only the first
-      # cron line is used in that case and all other ones are ignored.
-      def strict_cron_parsing!
-        @strict_cron_parsing = true
-      end
+      def natural_cron_parsing_mode=(mode)
+        unless %i[single strict].include?(mode)
+          raise ArgumentError, "Unknown natural cron parsing mode: #{mode.inspect}"
+        end
 
-      def strict_cron_parsing?
-        @strict_cron_parsing
+        @natural_cron_parsing_mode = mode
       end
     end
   end

--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -597,12 +597,16 @@ module Sidekiq
       end
 
       def do_parse_cron(cron)
-        if Sidekiq::Cron.configuration.strict_cron_parsing?
+        case Sidekiq::Cron.configuration.natural_cron_parsing_mode
+        when :single
+          Fugit.do_parse_cronish(cron)
+        when :strict
           Fugit.parse_cron(cron) || # Ex. '11 1 * * 1'
           Fugit.parse_nat(cron, :multi => :fail) || # Ex. 'every Monday at 01:11'
           fail(ArgumentError.new("invalid cron string #{cron.inspect}"))
         else
-          Fugit.do_parse_cronish(cron)
+          mode = Sidekiq::Cron.configuration.natural_cron_parsing_mode
+          raise ArgumentError, "Unknown natural cron parsing mode: #{mode.inspect}"
         end
       end
 

--- a/test/unit/job_test.rb
+++ b/test/unit/job_test.rb
@@ -111,14 +111,13 @@ describe "Cron Job" do
       @job.klass = "ExampleJob"
       assert @job.valid?
 
-      Sidekiq::Cron.configuration.strict_cron_parsing!
+      Sidekiq::Cron.configuration.natural_cron_parsing_mode = :strict
 
       refute @job.valid?
       assert @job.errors.is_a?(Array)
       assert @job.errors.any?{|e| e.include?("cron")}, "Should have error for cron"
     ensure
-      Sidekiq::Cron.configuration = nil
-      Sidekiq::Cron.configure
+      Sidekiq::Cron.configuration.natural_cron_parsing_mode = :single
     end
 
     it "return false on save" do
@@ -164,27 +163,25 @@ describe "Cron Job" do
     end
 
     it "should suppport cron format in strict mode" do
-      Sidekiq::Cron.configuration.strict_cron_parsing!
+      Sidekiq::Cron.configuration.natural_cron_parsing_mode = :strict
 
       @args[:cron] = "55 * * * *"
       @job = Sidekiq::Cron::Job.new(@args)
       assert @job.valid?
       assert_equal Fugit::Cron.new("55 * * * *"), @job.send(:parsed_cron)
     ensure
-      Sidekiq::Cron.configuration = nil
-      Sidekiq::Cron.configure
+      Sidekiq::Cron.configuration.natural_cron_parsing_mode = :single
     end
 
     it "should suppport natural language format in strict mode" do
-      Sidekiq::Cron.configuration.strict_cron_parsing!
+      Sidekiq::Cron.configuration.natural_cron_parsing_mode = :strict
 
       @args[:cron] = "every 3 hours"
       @job = Sidekiq::Cron::Job.new(@args)
       assert @job.valid?
       assert_equal Fugit::Cron.new("0 */3 * * *"), @job.send(:parsed_cron)
     ensure
-      Sidekiq::Cron.configuration = nil
-      Sidekiq::Cron.configure
+      Sidekiq::Cron.configuration.natural_cron_parsing_mode = :single
     end
   end
 

--- a/test/unit/job_test.rb
+++ b/test/unit/job_test.rb
@@ -105,6 +105,22 @@ describe "Cron Job" do
       assert @job.errors.any?{|e| e.include?("cron")}, "Should have error for cron"
     end
 
+    it "is invalid when parsing multiple cron lines in strict mode" do
+      @job.cron = "every Wednesday at 5:30 and 6:45"
+      @job.name = "example job"
+      @job.klass = "ExampleJob"
+      assert @job.valid?
+
+      Sidekiq::Cron.configuration.strict_cron_parsing!
+
+      refute @job.valid?
+      assert @job.errors.is_a?(Array)
+      assert @job.errors.any?{|e| e.include?("cron")}, "Should have error for cron"
+    ensure
+      Sidekiq::Cron.configuration = nil
+      Sidekiq::Cron.configure
+    end
+
     it "return false on save" do
       refute @job.save
     end
@@ -145,6 +161,30 @@ describe "Cron Job" do
       @job = Sidekiq::Cron::Job.new(@args)
       assert @job.valid?
       assert_equal Fugit::Cron.new("0 */3 * * *"), @job.send(:parsed_cron)
+    end
+
+    it "should suppport cron format in strict mode" do
+      Sidekiq::Cron.configuration.strict_cron_parsing!
+
+      @args[:cron] = "55 * * * *"
+      @job = Sidekiq::Cron::Job.new(@args)
+      assert @job.valid?
+      assert_equal Fugit::Cron.new("55 * * * *"), @job.send(:parsed_cron)
+    ensure
+      Sidekiq::Cron.configuration = nil
+      Sidekiq::Cron.configure
+    end
+
+    it "should suppport natural language format in strict mode" do
+      Sidekiq::Cron.configuration.strict_cron_parsing!
+
+      @args[:cron] = "every 3 hours"
+      @job = Sidekiq::Cron::Job.new(@args)
+      assert @job.valid?
+      assert_equal Fugit::Cron.new("0 */3 * * *"), @job.send(:parsed_cron)
+    ensure
+      Sidekiq::Cron.configuration = nil
+      Sidekiq::Cron.configure
     end
   end
 


### PR DESCRIPTION
This adds a configuration option for stricter cron string parsing.

Specifically, I wanted to avoid the possibility of a natural language cron string being parsed into multiple cron lines and then everything but the first cron line getting ignored. This is the default when using `Fugit.do_parse_cron`.

```rb
irb(main):005:0> Fugit.do_parse("every day at 3:15 and 4:30")
=> #<Fugit::Cron:0x000000011100e170 @original="15 3 * * *", @cron_s=nil, @day_and=nil, @seconds=[0], @minutes=[15], @hours=[3], @monthdays=nil, @months=nil, @weekdays=nil, @zone=nil, @timezone=nil>
irb(main):006:0> Fugit.do_parse("every day at 3:15 and 4:30", :multi => :fail)
...
ArgumentError (multiple crons in "every day at 3:15 and 4:30" - {:monthday=>(slot :monthday "*" {:weak=>true})})
```

We use the `:multi => :fail` option to throw an error in those situations.

Closes: https://github.com/sidekiq-cron/sidekiq-cron/issues/450

CC: @jmettraux