### PR TITLE
Prepare release v2.0.0.rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 - Allows symbol keys in `.load_from_array!` (https://github.com/sidekiq-cron/sidekiq-cron/pull/458)
 - Add natural language parsing mode (https://github.com/sidekiq-cron/sidekiq-cron/pull/459)
 - Add ability to configure the past scheduled time threshold (https://github.com/sidekiq-cron/sidekiq-cron/pull/465)
-- Docs: clarify worker vs process  (https://github.com/sidekiq-cron/sidekiq-cron/issues/453)
+- Docs: clarify worker vs process terminology (https://github.com/sidekiq-cron/sidekiq-cron/issues/453)
 
 ## 1.12.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.0.0.rc1
+
+- Introduce `Namespacing` (https://github.com/sidekiq-cron/sidekiq-cron/pull/268)
+- Human readable cron format in UI (https://github.com/sidekiq-cron/sidekiq-cron/pull/445)
+- Add Bahasa Indonesia locale (https://github.com/sidekiq-cron/sidekiq-cron/pull/446)
+- Fetch queue name from ActiveJob class (https://github.com/sidekiq-cron/sidekiq-cron/pull/448)
+- Add natural language parsing mode (https://github.com/sidekiq-cron/sidekiq-cron/pull/459)
+
 ## 1.12.0
 
 - Remove Sidekiq.server? check from schedule loader (https://github.com/sidekiq-cron/sidekiq-cron/pull/436)
@@ -61,7 +69,7 @@ All notable changes to this project will be documented in this file.
 
 ## 1.5.1
 
--  Fixes an issue that prevented the gem to work in previous Sidekiq versions (https://github.com/sidekiq-cron/sidekiq-cron/pull/335)
+- Fixes an issue that prevented the gem to work in previous Sidekiq versions (https://github.com/sidekiq-cron/sidekiq-cron/pull/335)
 
 ## 1.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ All notable changes to this project will be documented in this file.
 - Human readable cron format in UI (https://github.com/sidekiq-cron/sidekiq-cron/pull/445)
 - Add Bahasa Indonesia locale (https://github.com/sidekiq-cron/sidekiq-cron/pull/446)
 - Fetch queue name from ActiveJob class (https://github.com/sidekiq-cron/sidekiq-cron/pull/448)
+- Allows symbol keys in `.load_from_array!` (https://github.com/sidekiq-cron/sidekiq-cron/pull/458)
 - Add natural language parsing mode (https://github.com/sidekiq-cron/sidekiq-cron/pull/459)
+- Add ability to configure the past scheduled time threshold (https://github.com/sidekiq-cron/sidekiq-cron/pull/465)
+- Docs: clarify worker vs process  (https://github.com/sidekiq-cron/sidekiq-cron/issues/453)
 
 ## 1.12.0
 

--- a/lib/sidekiq/cron/version.rb
+++ b/lib/sidekiq/cron/version.rb
@@ -2,6 +2,6 @@
 
 module Sidekiq
   module Cron
-    VERSION = "1.12.0"
+    VERSION = "2.0.0.rc1"
   end
 end


### PR DESCRIPTION
Full diff: https://github.com/sidekiq-cron/sidekiq-cron/compare/v1.12.0...master

@ondrejbartas @honzasterba Do you agree with this release? Since [`namespaces`](https://github.com/sidekiq-cron/sidekiq-cron#namespacing) is a quite big feature (although retro-compatible with v1), I think it's good timing to start a new major. My idea is to launch it first as a release candidate and then, in some weeks, make the official v2 release.