### PR TITLE
Require at least fugit >= 1.11.1

### DIFF
--- a/sidekiq-cron.gemspec
+++ b/sidekiq-cron.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.7"
 
   s.add_dependency("cronex", ">= 0.13.0")
-  s.add_dependency("fugit", "~> 1.8")
+  s.add_dependency("fugit", "~> 1.8", ">= 1.11.1")
   s.add_dependency("globalid", ">= 1.0.1")
   s.add_dependency("sidekiq", ">= 6")
 


### PR DESCRIPTION
https://github.com/floraison/fugit/issues/104

Prevent Fugit::Nat.parse choking on large input, limit at 256 chars