### PR TITLE
Fix: according to documentation, `.create` should return true/false

### DIFF
--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -490,6 +490,8 @@ module Sidekiq
           conn.zadd(job_enqueued_key, time.to_f.to_s, formatted_last_time(time).to_s) unless exists == true || exists == 1
         end
         Sidekiq.logger.info { "Cron Jobs - added job with name #{@name} in the namespace #{@namespace}" }
+
+        true
       end
 
       def save_last_enqueue_time

--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -487,9 +487,12 @@ module Sidekiq
           # Add information about last time! - don't enque right after scheduler poller starts!
           time = Time.now.utc
           exists = conn.public_send(REDIS_EXISTS_METHOD, job_enqueued_key)
-          conn.zadd(job_enqueued_key, time.to_f.to_s, formatted_last_time(time).to_s) unless exists == true || exists == 1
+
+          unless exists == true || exists == 1
+            conn.zadd(job_enqueued_key, time.to_f.to_s, formatted_last_time(time).to_s)
+            Sidekiq.logger.info { "Cron Jobs - added job with name #{@name} in the namespace #{@namespace}" }
+          end
         end
-        Sidekiq.logger.info { "Cron Jobs - added job with name #{@name} in the namespace #{@namespace}" }
 
         true
       end


### PR DESCRIPTION
Related to https://github.com/sidekiq-cron/sidekiq-cron/issues/471

@markets I fixed it in the most easy way at the moment: by reaching the end of the method we can "suppose" that everything worked as expected and it can return `true`.

Actually, in the `Sidekiq.redis` block we are calling some redis commands (`SADD`, `HSET`, `ZADD`) but the code is not checking their return values. It's unlikely that those commands fail, unless a connection error occurs (but that would raise an expetion, I suppose!). So this might be good enough. What do you think?