### PR TITLE
Update How Redis Values Are Stored on `save`

### DIFF
--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -482,7 +482,7 @@ module Sidekiq
           conn.sadd self.class.jobs_key(@namespace), [redis_key]
 
           # Add information for this job!
-          conn.hset redis_key, to_hash.transform_values { |v| v || '' }.flatten
+          conn.hset redis_key, to_hash.transform_values! { |v| v || '' }.flatten
 
           # Add information about last time! - don't enque right after scheduler poller starts!
           time = Time.now.utc

--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -482,7 +482,7 @@ module Sidekiq
           conn.sadd self.class.jobs_key(@namespace), [redis_key]
 
           # Add information for this job!
-          conn.hset redis_key, to_hash.transform_values! { |v| v || '' }
+          conn.hset redis_key, *to_hash.transform_values { |v| v || '' }.flatten
 
           # Add information about last time! - don't enque right after scheduler poller starts!
           time = Time.now.utc

--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -482,7 +482,7 @@ module Sidekiq
           conn.sadd self.class.jobs_key(@namespace), [redis_key]
 
           # Add information for this job!
-          conn.hset redis_key, *to_hash.transform_values { |v| v || '' }.flatten
+          conn.hset redis_key, to_hash.transform_values { |v| v || '' }.flatten
 
           # Add information about last time! - don't enque right after scheduler poller starts!
           time = Time.now.utc


### PR DESCRIPTION
Resolves https://github.com/sidekiq-cron/sidekiq-cron/issues/478

The current way of setting values is to use a hash. As noted in the issue attached, this format is marked as deprecated by Ruby 3. The following warning is thrown:

```
/usr/local/bundle/gems/sidekiq-cron-1.10.1/lib/sidekiq/cron/job.rb:472: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```

This will instead pass an array to Redis. This is how [`hmset`](https://www.rubydoc.info/github/ezmobius/redis-rb/Redis:hmset) accepts arguments. Also, `hset` is preferred over `hmset` as Redis has deprecated the `hmset` command.

## Tested

I was able to get all tests to pass locally

I can also see the keys being set correctly via the `redis-cli`:

```
> HGET cron_job:foo_job description
"A temporary job to check I am alive"
```