### PR TITLE
Add compatibility with Sidekiq 7.3+ and remove inline styles

### DIFF
--- a/lib/sidekiq/cron/views/cron.erb
+++ b/lib/sidekiq/cron/views/cron.erb
@@ -31,7 +31,7 @@
 <div class='row'>
   <div class="col-sm-12 summary_bar">
     <ul class="list-unstyled summary row">
-      <% @namespaces.sort_by { |namespace| namespace[:name] } .each do |namespace| %>
+      <% @namespaces.sort_by { |namespace| namespace[:name] }.each do |namespace| %>
         <li class="col-sm-1">
           <a href="<%= root_path %>cron/namespaces/<%= namespace[:name] %>">
             <span class="count"><%= namespace[:count] %></span>
@@ -47,16 +47,18 @@
 <% if @cron_jobs.size > 0 %>
   <table class="table table-hover table-bordered table-striped table-white">
     <thead>
+    <tr>
       <th><%= t('Status') %></th>
-      <th><%= t('Name') %></th>
+      <th width="50%"><%= t('Name') %></th>
       <th><%= t('Cron string') %></th>
       <th><%= t('Last enqueued') %></th>
-      <th width="180"><%= t('Actions')%></th>
+      <th width="180"><%= t('Actions') %></th>
+    </tr>
     </thead>
 
     <tbody>
-      <% @cron_jobs.sort{|a,b| a.sort_name <=> b.sort_name }.each_with_index do |job, index| %>
-        <% klass = "#{job.status == 'disabled' ? "bg-danger text-muted": ""}" %>
+      <% @cron_jobs.sort{ |a,b| a.sort_name <=> b.sort_name }.each do |job| %>
+        <% klass = (job.status == 'disabled') ? 'bg-danger text-muted' : '' %>
         <tr>
           <td class="<%= klass %>"><%= t job.status %></td>
           <td class="<%= klass %>">
@@ -64,21 +66,14 @@
               <b class="<%= klass %>"><%= job.name %></b>
             </a>
             <br/>
-            <small>
             <% if job.message and job.message.to_s.size > 100 %>
-              <% if Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new("6.3.0") %>
-                <button data-toggle="job_<%= index %>" class="btn btn-warn btn-xs"><%= t('ShowAll')%></button>
-                <div class="toggle" id="job_<%= index %>" style="display: inline;"><%= job.message[0..100] + "... " %></div>
-                <div class="toggle" id="job_<%= index %>_full" style="display: none;"><%= job.message %></div>
-              <% else %>
-                <button data-toggle="collapse" data-target=".worker_<%= index %>" class="btn btn-warn btn-xs"><%= t('ShowAll')%></button>
-                <div class="toggle worker_<%= index %>" style="display: inline;"><%= job.message[0..100] + "... " %></div>
-                <div class="toggle worker_<%= index %>" style="display: none;"><%= job.message %></div>
-              <% end %>
+              <details>
+                <summary class="btn btn-warn btn-xs">Show message</summary>
+                <p><small><%= job.message %></small></p>
+              </details>
             <% else %>
-              <%= job.message %>
+              <small><%= job.message %></small>
             <% end %>
-            </small>
           </td>
           <td class="<%= klass %>"><b><%= job.human_cron %><br/><small><%= job.cron.gsub(" ", "&nbsp;") %></small></b></td>
           <td class="<%= klass %>"><%= job.last_enqueue_time ? relative_time(job.last_enqueue_time) : "-" %></td>

--- a/lib/sidekiq/cron/views/cron.erb
+++ b/lib/sidekiq/cron/views/cron.erb
@@ -5,7 +5,7 @@
       <small><%= @current_namespace %></small>
     </h3>
   </div>
-  <div class='col-sm-7 pull-right' style="margin-top: 20px; margin-bottom: 10px;">
+  <div class='col-sm-7 pull-right h2'>
     <% if @cron_jobs.size > 0 %>
       <form action="<%= root_path %>cron/namespaces/<%= @current_namespace %>/all/delete" method="post" class="pull-right">
         <%= csrf_tag if respond_to?(:csrf_tag) %>
@@ -56,14 +56,14 @@
 
     <tbody>
       <% @cron_jobs.sort{|a,b| a.sort_name <=> b.sort_name }.each_with_index do |job, index| %>
-        <% style = "#{job.status == 'disabled' ? "background: #ecc; color: #585454;": ""}" %>
+        <% klass = "#{job.status == 'disabled' ? "bg-danger text-muted": ""}" %>
         <tr>
-          <td style="<%= style %>"><%= t job.status %></td>
-          <td style="<%= style %>">
+          <td class="<%= klass %>"><%= t job.status %></td>
+          <td class="<%= klass %>">
             <a href="<%= root_path %>cron/namespaces/<%= @current_namespace %>/jobs/<%= CGI.escape(job.name).gsub('+', '%20') %>" title="<%= job.description %>">
-              <b style="<%= style %>"><%= job.name %></b>
+              <b class="<%= klass %>"><%= job.name %></b>
             </a>
-            <hr style="margin:3px;border:0;">
+            <br/>
             <small>
             <% if job.message and job.message.to_s.size > 100 %>
               <% if Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new("6.3.0") %>
@@ -80,9 +80,9 @@
             <% end %>
             </small>
           </td>
-          <td style="<%= style %>"><b><%= job.human_cron %><br/><small><%= job.cron.gsub(" ", "&nbsp;") %></small></b></td>
-          <td style="<%= style %>"><%= job.last_enqueue_time ? relative_time(job.last_enqueue_time) : "-" %></td>
-          <td style="<%= style %>">
+          <td class="<%= klass %>"><b><%= job.human_cron %><br/><small><%= job.cron.gsub(" ", "&nbsp;") %></small></b></td>
+          <td class="<%= klass %>"><%= job.last_enqueue_time ? relative_time(job.last_enqueue_time) : "-" %></td>
+          <td class="<%= klass %>">
             <% if job.status == 'enabled' %>
               <form action="<%= root_path %>cron/namespaces/<%= @current_namespace %>/jobs/<%= CGI.escape(job.name).gsub('+', '%20') %>/enque" method="post">
                 <%= csrf_tag if respond_to?(:csrf_tag) %>
@@ -103,7 +103,7 @@
               </form>
               <form action="<%= root_path %>cron/namespaces/<%= @current_namespace %>/jobs/<%= CGI.escape(job.name).gsub('+', '%20') %>/delete" method="post">
                 <%= csrf_tag if respond_to?(:csrf_tag) %>
-                <input class='btn btn-xs btn-danger pull-left' type="submit" name="delete" value="<%= t('Delete') %>" data-confirm="<%= t('AreYouSureDeleteCronJob', :job => job.name) %>"/>
+                <input class='btn btn-xs btn-danger pull-left help-block' type="submit" name="delete" value="<%= t('Delete') %>" data-confirm="<%= t('AreYouSureDeleteCronJob', :job => job.name) %>"/>
               </form>
             <% end %>
           </td>

--- a/lib/sidekiq/cron/views/cron_show.erb
+++ b/lib/sidekiq/cron/views/cron_show.erb
@@ -5,25 +5,25 @@
       <small><%= @job.name %></small>
     </h3>
   </div>
-  <div class="span col-sm-7 pull-right" style="margin-top: 20px; margin-bottom: 10px;">
+  <div class="span col-sm-7 pull-right h2">
     <% cron_job_path = "#{root_path}cron/namespaces/#{@current_namespace}/jobs/#{CGI.escape(@job.name).gsub('+', '%20')}" %>
     <form action="<%= cron_job_path %>/enque?redirect=<%= cron_job_path %>" class="pull-right" method="post">
       <%= csrf_tag if respond_to?(:csrf_tag) %>
       <input class="btn btn-warn pull-left" name="enque" type="submit" value="<%= t('EnqueueNow') %>" data-confirm="<%= t('AreYouSureEnqueueCronJob', :job => @job.name) %>" />
     </form>
     <% if @job.status == 'enabled' %>
-      <form action="<%= cron_job_path %>/disable?redirect=<%= cron_job_path %>" method="post">
+      <form action="<%= cron_job_path %>/disable?redirect=<%= cron_job_path %>" class="pull-right" method="post">
         <%= csrf_tag if respond_to?(:csrf_tag) %>
         <input class="btn btn-warn pull-left" name="disable" type="submit" value="<%= t('Disable') %>" />
       </form>
     <% else %>
-      <form action="<%= cron_job_path %>/enable?redirect=<%= cron_job_path %>" method="post">
+      <form action="<%= cron_job_path %>/enable?redirect=<%= cron_job_path %>" class="pull-right" method="post">
         <%= csrf_tag if respond_to?(:csrf_tag) %>
         <input class="btn btn-warn pull-left" name="enable" type="submit" value="<%= t('Enable') %>" />
       </form>
-      <form action="<%= cron_job_path %>/delete" method="post">
+      <form action="<%= cron_job_path %>/delete" class="pull-right" method="post">
         <%= csrf_tag if respond_to?(:csrf_tag) %>
-        <input class="btn btn-danger" data-confirm="<%= t('AreYouSureDeleteCronJob', :job => @job.name) %>" name="delete" type="submit" value="<%= t('Delete') %>" />
+        <input class="btn btn-danger pull-left" data-confirm="<%= t('AreYouSureDeleteCronJob', :job => @job.name) %>" name="delete" type="submit" value="<%= t('Delete') %>" />
       </form>
     <% end %>
   </div>

--- a/lib/sidekiq/cron/web.rb
+++ b/lib/sidekiq/cron/web.rb
@@ -6,7 +6,7 @@ if defined?(Sidekiq::Web)
     Sidekiq::Web.register(
       Sidekiq::Cron::WebExtension, # Class which contains the HTTP actions, required
       name: "cron", # the name of the extension, used to namespace assets
-      tab: "Cron Jobs", # labels(s) of the UI tabs
+      tab: "Cron", # labels(s) of the UI tabs
       index: "cron", # index route(s) for each tab
     )
   else

--- a/lib/sidekiq/cron/web.rb
+++ b/lib/sidekiq/cron/web.rb
@@ -2,6 +2,15 @@ require "sidekiq/cron/web_extension"
 require "sidekiq/cron/job"
 
 if defined?(Sidekiq::Web)
-  Sidekiq::Web.register Sidekiq::Cron::WebExtension
-  Sidekiq::Web.tabs["Cron"] = "cron"
+  if Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new('7.3.0')
+    Sidekiq::Web.register(
+      Sidekiq::Cron::WebExtension, # Class which contains the HTTP actions, required
+      name: "cron", # the name of the extension, used to namespace assets
+      tab: "Cron Jobs", # labels(s) of the UI tabs
+      index: "cron", # index route(s) for each tab
+    )
+  else
+    Sidekiq::Web.register Sidekiq::Cron::WebExtension
+    Sidekiq::Web.tabs["Cron"] = "cron"
+  end
 end

--- a/sidekiq-cron.gemspec
+++ b/sidekiq-cron.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_dependency("cronex", ">= 0.13.0")
   s.add_dependency("fugit", "~> 1.8", ">= 1.11.1")
   s.add_dependency("globalid", ">= 1.0.1")
-  s.add_dependency("sidekiq", ">= 6")
+  s.add_dependency("sidekiq", ">= 6.5.0")
 
   s.add_development_dependency("minitest", "~> 5.15")
   s.add_development_dependency("mocha", "~> 2.1")


### PR DESCRIPTION
#### This PR resolves https://github.com/sidekiq-cron/sidekiq-cron/issues/468

### Summary:
#### Support for Sidekiq 7.3+:
- Updated the code to use the new API for web extensions in Sidekiq 7.3 and above.
- Added checks to ensure it still works with older Sidekiq versions.

#### Remove Inline Styles:
- Removed all inline CSS styles from the views to make the code cleaner.
- Used existing CSS classes instead, so the design stays consistent without extra styles.

### Changes:
#### `cron.erb` and `cron_show.erb`:
- Removed inline styles and used existing CSS classes.
- Simplified some parts of the view to make the code easier to maintain.

#### `web.rb`:
- Added logic to register the web extension using the new Sidekiq 7.3+ API.
- Included a fallback for older Sidekiq versions to keep everything working.

### References:
- https://github.com/sidekiq/sidekiq/pull/6292
- https://github.com/sidekiq-cron/sidekiq-cron/issues/468#issuecomment-2341467667