### PR TITLE
Add confirmation for enqueuing disabled cron jobs and refactor job name escaping

### DIFF
--- a/lib/sidekiq/cron/views/cron.erb
+++ b/lib/sidekiq/cron/views/cron.erb
@@ -59,10 +59,11 @@
     <tbody>
       <% @cron_jobs.sort{ |a,b| a.sort_name <=> b.sort_name }.each do |job| %>
         <% klass = (job.status == 'disabled') ? 'bg-danger text-muted' : '' %>
+        <% escaped_job_name = CGI.escape(job.name).gsub('+', '%20') %>
         <tr>
           <td class="<%= klass %>"><%= t job.status %></td>
           <td class="<%= klass %>">
-            <a href="<%= root_path %>cron/namespaces/<%= @current_namespace %>/jobs/<%= CGI.escape(job.name).gsub('+', '%20') %>" title="<%= job.description %>">
+            <a href="<%= root_path %>cron/namespaces/<%= @current_namespace %>/jobs/<%= escaped_job_name %>" title="<%= job.description %>">
               <b class="<%= klass %>"><%= job.name %></b>
             </a>
             <br/>
@@ -79,24 +80,24 @@
           <td class="<%= klass %>"><%= job.last_enqueue_time ? relative_time(job.last_enqueue_time) : "-" %></td>
           <td class="<%= klass %>">
             <% if job.status == 'enabled' %>
-              <form action="<%= root_path %>cron/namespaces/<%= @current_namespace %>/jobs/<%= CGI.escape(job.name).gsub('+', '%20') %>/enque" method="post">
+              <form action="<%= root_path %>cron/namespaces/<%= @current_namespace %>/jobs/<%= escaped_job_name %>/enque" method="post">
                 <%= csrf_tag if respond_to?(:csrf_tag) %>
                 <input class='btn btn-warn btn-xs pull-left' type="submit" name="enque" value="<%= t('EnqueueNow') %>" data-confirm="<%= t('AreYouSureEnqueueCronJob', :job => job.name) %>"/>
               </form>
-              <form action="<%= root_path %>cron/namespaces/<%= @current_namespace %>/jobs/<%= CGI.escape(job.name).gsub('+', '%20') %>/disable" method="post">
+              <form action="<%= root_path %>cron/namespaces/<%= @current_namespace %>/jobs/<%= escaped_job_name %>/disable" method="post">
                 <%= csrf_tag if respond_to?(:csrf_tag) %>
                 <input class='btn btn-warn btn-xs pull-left' type="submit" name="disable" value="<%= t('Disable') %>"/>
               </form>
             <% else %>
-              <form action="<%= root_path %>cron/namespaces/<%= @current_namespace %>/jobs/<%= CGI.escape(job.name).gsub('+', '%20') %>/enque" method="post">
+              <form action="<%= root_path %>cron/namespaces/<%= @current_namespace %>/jobs/<%= escaped_job_name %>/enque" method="post">
                 <%= csrf_tag if respond_to?(:csrf_tag) %>
-                <input class='btn btn-warn btn-xs pull-left' type="submit" name="enque" value="<%= t('EnqueueNow') %>"/>
+                <input class='btn btn-warn btn-xs pull-left' type="submit" name="enque" value="<%= t('EnqueueNow') %>" data-confirm="<%= t('AreYouSureEnqueueCronJob', :job => job.name) %>"/>
               </form>
-              <form action="<%= root_path %>cron/namespaces/<%= @current_namespace %>/jobs/<%= CGI.escape(job.name).gsub('+', '%20') %>/enable" method="post">
+              <form action="<%= root_path %>cron/namespaces/<%= @current_namespace %>/jobs/<%= escaped_job_name %>/enable" method="post">
                 <%= csrf_tag if respond_to?(:csrf_tag) %>
                 <input class='btn btn-warn btn-xs pull-left' type="submit" name="enable" value="<%= t('Enable') %>"/>
               </form>
-              <form action="<%= root_path %>cron/namespaces/<%= @current_namespace %>/jobs/<%= CGI.escape(job.name).gsub('+', '%20') %>/delete" method="post">
+              <form action="<%= root_path %>cron/namespaces/<%= @current_namespace %>/jobs/<%= escaped_job_name %>/delete" method="post">
                 <%= csrf_tag if respond_to?(:csrf_tag) %>
                 <input class='btn btn-xs btn-danger pull-left help-block' type="submit" name="delete" value="<%= t('Delete') %>" data-confirm="<%= t('AreYouSureDeleteCronJob', :job => job.name) %>"/>
               </form>


### PR DESCRIPTION
This PR includes two improvements to the `cron.erb` view:

- **Add Confirmation for Disabled Jobs**: Ensures that when attempting to enqueue a disabled cron job, a confirmation dialog (`data-confirm`) is displayed. This brings consistency in behaviour, as the same confirmation is already shown for enabled jobs.

- **Refactor Job Name Escaping**: Replaces repeated occurrences of `CGI.escape(job.name).gsub('+', '%20')` with a single variable `escaped_job_name`, reducing redundancy and improving code readability.

These changes should improve the user experience by preventing accidental enqueuing of disabled jobs and simplify the codebase.

#### References:
- Closes https://github.com/sidekiq-cron/sidekiq-cron/issues/481