### PR TITLE
Restrict namespace from using '*' and fix job actions for wildcard namespaces

### DIFF
--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -447,6 +447,7 @@ module Sidekiq
 
         errors << "'name' must be set" if @name.nil? || @name.size == 0
         errors << "'namespace' must be set" if @namespace.nil? || @namespace.size == 0
+        errors << "'namespace' cannot be '*'" if @namespace == "*"
 
         if @cron.nil? || @cron.size == 0
           errors << "'cron' must be set"

--- a/lib/sidekiq/cron/views/cron.erb
+++ b/lib/sidekiq/cron/views/cron.erb
@@ -63,7 +63,7 @@
         <tr>
           <td class="<%= klass %>"><%= t job.status %></td>
           <td class="<%= klass %>">
-            <a href="<%= root_path %>cron/namespaces/<%= @current_namespace %>/jobs/<%= escaped_job_name %>" title="<%= job.description %>">
+            <a href="<%= root_path %>cron/namespaces/<%= job.namespace %>/jobs/<%= escaped_job_name %>" title="<%= job.description %>">
               <b class="<%= klass %>"><%= job.name %></b>
             </a>
             <br/>
@@ -80,24 +80,24 @@
           <td class="<%= klass %>"><%= job.last_enqueue_time ? relative_time(job.last_enqueue_time) : "-" %></td>
           <td class="<%= klass %>">
             <% if job.status == 'enabled' %>
-              <form action="<%= root_path %>cron/namespaces/<%= @current_namespace %>/jobs/<%= escaped_job_name %>/enque" method="post">
+              <form action="<%= root_path %>cron/namespaces/<%= job.namespace %>/jobs/<%= escaped_job_name %>/enque" method="post">
                 <%= csrf_tag if respond_to?(:csrf_tag) %>
                 <input class='btn btn-warn btn-xs pull-left' type="submit" name="enque" value="<%= t('EnqueueNow') %>" data-confirm="<%= t('AreYouSureEnqueueCronJob', :job => job.name) %>"/>
               </form>
-              <form action="<%= root_path %>cron/namespaces/<%= @current_namespace %>/jobs/<%= escaped_job_name %>/disable" method="post">
+              <form action="<%= root_path %>cron/namespaces/<%= job.namespace %>/jobs/<%= escaped_job_name %>/disable" method="post">
                 <%= csrf_tag if respond_to?(:csrf_tag) %>
                 <input class='btn btn-warn btn-xs pull-left' type="submit" name="disable" value="<%= t('Disable') %>"/>
               </form>
             <% else %>
-              <form action="<%= root_path %>cron/namespaces/<%= @current_namespace %>/jobs/<%= escaped_job_name %>/enque" method="post">
+              <form action="<%= root_path %>cron/namespaces/<%= job.namespace %>/jobs/<%= escaped_job_name %>/enque" method="post">
                 <%= csrf_tag if respond_to?(:csrf_tag) %>
                 <input class='btn btn-warn btn-xs pull-left' type="submit" name="enque" value="<%= t('EnqueueNow') %>" data-confirm="<%= t('AreYouSureEnqueueCronJob', :job => job.name) %>"/>
               </form>
-              <form action="<%= root_path %>cron/namespaces/<%= @current_namespace %>/jobs/<%= escaped_job_name %>/enable" method="post">
+              <form action="<%= root_path %>cron/namespaces/<%= job.namespace %>/jobs/<%= escaped_job_name %>/enable" method="post">
                 <%= csrf_tag if respond_to?(:csrf_tag) %>
                 <input class='btn btn-warn btn-xs pull-left' type="submit" name="enable" value="<%= t('Enable') %>"/>
               </form>
-              <form action="<%= root_path %>cron/namespaces/<%= @current_namespace %>/jobs/<%= escaped_job_name %>/delete" method="post">
+              <form action="<%= root_path %>cron/namespaces/<%= job.namespace %>/jobs/<%= escaped_job_name %>/delete" method="post">
                 <%= csrf_tag if respond_to?(:csrf_tag) %>
                 <input class='btn btn-xs btn-danger pull-left help-block' type="submit" name="delete" value="<%= t('Delete') %>" data-confirm="<%= t('AreYouSureDeleteCronJob', :job => job.name) %>"/>
               </form>

--- a/test/unit/job_test.rb
+++ b/test/unit/job_test.rb
@@ -105,6 +105,13 @@ describe "Cron Job" do
       assert @job.errors.any?{|e| e.include?("cron")}, "Should have error for cron"
     end
 
+    it "return false for valid? when namespace is '*'" do
+      @job.namespace = "*"
+      refute @job.valid?
+      assert @job.errors.is_a?(Array)
+      assert @job.errors.any?{|e| e.include?("namespace")}, "Should have error for namespace"
+    end
+
     it "is invalid when parsing multiple cron lines in strict mode" do
       @job.cron = "every Wednesday at 5:30 and 6:45"
       @job.name = "example job"


### PR DESCRIPTION
This PR introduces a validation that disallows `*` as a valid namespace in sidekiq-cron jobs. It also fixes an issue where individual job actions like "Enqueue", "Delete", "Enable", and "Disable" fail when all jobs are listed using the '*' wildcard. The job's actual namespace is now correctly referenced for these actions. A test case has been added to ensure `*` is considered an invalid namespace.

Fixes: https://github.com/sidekiq-cron/sidekiq-cron/issues/483