### PR TITLE
Fix: Ensure date_as_argument option can be set from true to false in Sidekiq Cron jobs

### DIFF
--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -413,7 +413,7 @@ module Sidekiq
 
       # Export job data to hash.
       def to_hash
-        hash = {
+        {
           name: @name,
           namespace: @namespace,
           klass: @klass.to_s,
@@ -421,6 +421,7 @@ module Sidekiq
           description: @description,
           source: @source,
           args: @args.is_a?(String) ? @args : Sidekiq.dump_json(@args || []),
+          date_as_argument: date_as_argument? ? "1" : "0",
           message: @message.is_a?(String) ? @message : Sidekiq.dump_json(@message || {}),
           status: @status,
           active_job: @active_job ? "1" : "0",
@@ -429,18 +430,6 @@ module Sidekiq
           last_enqueue_time: serialized_last_enqueue_time,
           symbolize_args: symbolize_args? ? "1" : "0",
         }
-
-        if date_as_argument?
-          hash.merge!(date_as_argument: "1")
-        else
-          # Ensure that the `date_as_argument` field is removed from Redis when `date_as_argument` is false.
-          # This prevents stale values from persisting and ensures that changes to the config are correctly applied.
-          Sidekiq.redis do |conn|
-            conn.hdel(redis_key, 'date_as_argument')
-          end
-        end
-
-        hash
       end
 
       def errors

--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -432,6 +432,12 @@ module Sidekiq
 
         if date_as_argument?
           hash.merge!(date_as_argument: "1")
+        else
+          # Ensure that the `date_as_argument` field is removed from Redis when `date_as_argument` is false.
+          # This prevents stale values from persisting and ensures that changes to the config are correctly applied.
+          Sidekiq.redis do |conn|
+            conn.hdel(redis_key, 'date_as_argument')
+          end
         end
 
         hash

--- a/test/unit/job_test.rb
+++ b/test/unit/job_test.rb
@@ -370,7 +370,7 @@ describe "Cron Job" do
       assert_equal true, stored_job.date_as_argument?
     end
 
-    it 'does not store date_as_argument in Redis when false' do
+    it 'stores date_as_argument in Redis when false' do
       Sidekiq::Cron::Job.create(@args.merge(date_as_argument: false))
       stored_job = Sidekiq::Cron::Job.find(@args[:name])
       assert_equal false, stored_job.date_as_argument?

--- a/test/unit/job_test.rb
+++ b/test/unit/job_test.rb
@@ -354,7 +354,7 @@ describe "Cron Job" do
     end
   end
 
-  describe 'Handling date_as_argument in Sidekiq Cron Job' do
+  describe 'handling date_as_argument' do
     before do
       @args = {
         name: 'Test',
@@ -364,19 +364,19 @@ describe "Cron Job" do
       }
     end
 
-    it 'sets date_as_argument to true in the Sidekiq Cron Job' do
+    it 'sets date_as_argument to true' do
       Sidekiq::Cron::Job.create(@args.merge(date_as_argument: true))
       stored_job = Sidekiq::Cron::Job.find(@args[:name])
       assert_equal true, stored_job.date_as_argument?
     end
 
-    it 'sets date_as_argument to false in the Sidekiq Cron Job' do
+    it 'sets date_as_argument to false' do
       Sidekiq::Cron::Job.create(@args.merge(date_as_argument: false))
       stored_job = Sidekiq::Cron::Job.find(@args[:name])
       assert_equal false, stored_job.date_as_argument?
     end
 
-    it 'updates date_as_argument from true to false in the Sidekiq Cron Job' do
+    it 'updates date_as_argument from true to false' do
       Sidekiq::Cron::Job.create(@args.merge(date_as_argument: true))
       stored_job = Sidekiq::Cron::Job.find(@args[:name])
       assert_equal true, stored_job.date_as_argument?
@@ -386,7 +386,7 @@ describe "Cron Job" do
       assert_equal false, stored_job.date_as_argument?
     end
 
-    it 'updates date_as_argument from false to true in the Sidekiq Cron Job' do
+    it 'updates date_as_argument from false to true' do
       Sidekiq::Cron::Job.create(@args.merge(date_as_argument: false))
       stored_job = Sidekiq::Cron::Job.find(@args[:name])
       assert_equal false, stored_job.date_as_argument?
@@ -1451,7 +1451,7 @@ describe "Cron Job" do
       Sidekiq.redis do |conn|
         assert_equal conn.zcard(Sidekiq::Cron::Job.new(@args).send(:job_enqueued_key)), 1, "Should have one enqueued job"
       end
-      assert_equal Sidekiq::Queue.all.first&.size, 1, "Sidekiq queue 1 job in queue"
+      assert_equal Sidekiq::Queue.all.first.size, 1, "Sidekiq queue 1 job in queue"
 
       # 20 hours after.
       assert Sidekiq::Cron::Job.new(@args).test_and_enque_for_time! @time + 1 * 60 * 60
@@ -1460,7 +1460,7 @@ describe "Cron Job" do
       Sidekiq.redis do |conn|
         assert_equal conn.zcard(Sidekiq::Cron::Job.new(@args).send(:job_enqueued_key)), 2, "Should have two enqueued job"
       end
-      assert_equal Sidekiq::Queue.all.first&.size, 2, "Sidekiq queue 2 jobs in queue"
+      assert_equal Sidekiq::Queue.all.first.size, 2, "Sidekiq queue 2 jobs in queue"
 
       # 26 hour after.
       assert Sidekiq::Cron::Job.new(@args).test_and_enque_for_time! @time + 26 * 60 * 60
@@ -1469,7 +1469,7 @@ describe "Cron Job" do
       Sidekiq.redis do |conn|
         assert_equal conn.zcard(Sidekiq::Cron::Job.new(@args).send(:job_enqueued_key)), 1, "Should have one enqueued job - old jobs should be deleted"
       end
-      assert_equal Sidekiq::Queue.all.first&.size, 3, "Sidekiq queue 3 jobs in queue"
+      assert_equal Sidekiq::Queue.all.first.size, 3, "Sidekiq queue 3 jobs in queue"
     end
   end
 

--- a/test/unit/job_test.rb
+++ b/test/unit/job_test.rb
@@ -354,6 +354,39 @@ describe "Cron Job" do
     end
   end
 
+  describe 'Handling date_as_argument persistence in Redis' do
+    before do
+      @args = {
+        name: 'Test',
+        cron: '* * * * *',
+        queue: 'default',
+        klass: 'CronTestClass'
+      }
+    end
+
+    it 'stores date_as_argument in Redis when true' do
+      Sidekiq::Cron::Job.create(@args.merge(date_as_argument: true))
+      stored_job = Sidekiq::Cron::Job.find(@args[:name])
+      assert_equal true, stored_job.date_as_argument?
+    end
+
+    it 'does not store date_as_argument in Redis when false' do
+      Sidekiq::Cron::Job.create(@args.merge(date_as_argument: false))
+      stored_job = Sidekiq::Cron::Job.find(@args[:name])
+      assert_equal false, stored_job.date_as_argument?
+    end
+
+    it 'correctly updates Redis when changing date_as_argument from true to false' do
+      Sidekiq::Cron::Job.create(@args.merge(date_as_argument: true))
+      stored_job = Sidekiq::Cron::Job.find(@args[:name])
+      assert_equal true, stored_job.date_as_argument?
+
+      Sidekiq::Cron::Job.create(@args.merge(date_as_argument: false))
+      stored_job = Sidekiq::Cron::Job.find(@args[:name])
+      assert_equal false, stored_job.date_as_argument?
+    end
+  end
+
   describe '#sidekiq_worker_message' do
     before do
       @args = {

--- a/test/unit/job_test.rb
+++ b/test/unit/job_test.rb
@@ -901,58 +901,6 @@ describe "Cron Job" do
     end
   end
 
-  # @note sidekiq-cron 1.6.0 cannot process options correctly if any date_as_argument evaluates to true.
-  # This has been tested to resolve issues in environments where multiple sidekiq-cron versions are running when updating from 1.6.0
-  # See https://github.com/sidekiq-cron/sidekiq-cron/issues/350#issuecomment-1409798837 for more information.
-  describe "compat with sidekiq cron 1.6.0" do
-    describe "#to_hash with date_as_argument false" do
-      before do
-        @args = {
-          name: "Test",
-          cron: "* * * * *",
-          klass: "CronTestClass",
-          date_as_argument: false,
-        }
-        @job = Sidekiq::Cron::Job.new(@args)
-      end
-
-      it "should not have date_as_argument property" do
-        assert !@job.to_hash.key?(:date_as_argument)
-      end
-    end
-
-    describe "#to_hash with no date_as_argument option" do
-      before do
-        @args = {
-          name: "Test",
-          cron: "* * * * *",
-          klass: "CronTestClass",
-        }
-        @job = Sidekiq::Cron::Job.new(@args)
-      end
-
-      it "should not have date_as_argument property" do
-        assert !@job.to_hash.key?(:date_as_argument)
-      end
-    end
-
-    describe "#to_hash with date_as_argument" do
-      before do
-        @args = {
-          name: "Test",
-          cron: "* * * * *",
-          klass: "CronTestClass",
-          date_as_argument: true,
-        }
-        @job = Sidekiq::Cron::Job.new(@args)
-      end
-
-      it "should have date_as_argument property with value '1'" do
-        assert_equal @job.to_hash[:date_as_argument], '1'
-      end
-    end
-  end
-
   describe "save" do
     before do
       @args = {


### PR DESCRIPTION
#### Summary
This pull request fixes an issue where the `date_as_argument` option in Sidekiq Cron jobs cannot be changed from true to false once it has been set to true. The issue occurs because the Redis key for `date_as_argument` is not removed when the configuration is updated.

#### Changes
- Added logic to delete the `date_as_argument` field from Redis when `date_as_argument` is set to false.
- This ensures that stale values in Redis are cleared, allowing configuration changes to take effect as expected

Fixes: #472 