### PR TITLE
Fix redirection issues in web extension for namespace-specific routes

### DIFF
--- a/lib/sidekiq/cron/web_extension.rb
+++ b/lib/sidekiq/cron/web_extension.rb
@@ -56,24 +56,24 @@ module Sidekiq
 
         # Enqueue cron job.
         app.post '/cron/namespaces/:namespace/jobs/:name/enque' do
-          if job = Sidekiq::Cron::Job.find(route_params[:name], route_params[:namespace])
+          if (job = Sidekiq::Cron::Job.find(route_params[:name], route_params[:namespace]))
             job.enque!
           end
-          redirect params['redirect'] || "#{root_path}cron"
+          redirect params['redirect'] || "#{root_path}cron/namespaces/#{route_params[:namespace]}"
         end
 
         # Delete all schedules.
         app.post '/cron/namespaces/:namespace/all/delete' do
           Sidekiq::Cron::Job.all(route_params[:namespace]).each(&:destroy)
-          redirect "#{root_path}cron/namespaces/#{route_params[:namespace]}"
+          redirect params['redirect'] || "#{root_path}cron/namespaces/#{route_params[:namespace]}"
         end
 
         # Delete schedule.
         app.post '/cron/namespaces/:namespace/jobs/:name/delete' do
-          if job = Sidekiq::Cron::Job.find(route_params[:name], route_params[:namespace])
+          if (job = Sidekiq::Cron::Job.find(route_params[:name], route_params[:namespace]))
             job.destroy
           end
-          redirect "#{root_path}cron"
+          redirect params['redirect'] || "#{root_path}cron/namespaces/#{route_params[:namespace]}"
         end
 
         # Enable all jobs.
@@ -84,10 +84,10 @@ module Sidekiq
 
         # Enable job.
         app.post '/cron/namespaces/:namespace/jobs/:name/enable' do
-          if job = Sidekiq::Cron::Job.find(route_params[:name], route_params[:namespace])
+          if (job = Sidekiq::Cron::Job.find(route_params[:name], route_params[:namespace]))
             job.enable!
           end
-          redirect params['redirect'] || "#{root_path}cron"
+          redirect params['redirect'] || "#{root_path}cron/namespaces/#{route_params[:namespace]}"
         end
 
         # Disable all jobs.
@@ -98,10 +98,10 @@ module Sidekiq
 
         # Disable job.
         app.post '/cron/namespaces/:namespace/jobs/:name/disable' do
-          if job = Sidekiq::Cron::Job.find(route_params[:name], route_params[:namespace])
+          if (job = Sidekiq::Cron::Job.find(route_params[:name], route_params[:namespace]))
             job.disable!
           end
-          redirect params['redirect'] || "#{root_path}cron"
+          redirect params['redirect'] || "#{root_path}cron/namespaces/#{route_params[:namespace]}"
         end
       end
     end

--- a/lib/sidekiq/cron/web_extension.rb
+++ b/lib/sidekiq/cron/web_extension.rb
@@ -4,6 +4,13 @@ module Sidekiq
       def self.registered(app)
         app.settings.locales << File.join(File.expand_path("..", __FILE__), "locales")
 
+        app.helpers do
+          # This method constructs the URL for the cron jobs page within the specified namespace.
+          def namespace_redirect_path
+            "#{root_path}cron/namespaces/#{route_params[:namespace]}"
+          end
+        end
+
         # Index page of cron jobs.
         app.get '/cron' do
           view_path = File.join(File.expand_path("..", __FILE__), "views")
@@ -44,14 +51,14 @@ module Sidekiq
           if @job
             render(:erb, File.read(File.join(view_path, "cron_show.erb")))
           else
-            redirect "#{root_path}cron/namespaces/#{route_params[:namespace]}"
+            redirect namespace_redirect_path
           end
         end
 
         # Enque all cron jobs.
         app.post '/cron/namespaces/:namespace/all/enque' do
           Sidekiq::Cron::Job.all(route_params[:namespace]).each(&:enque!)
-          redirect params['redirect'] || "#{root_path}cron/namespaces/#{route_params[:namespace]}"
+          redirect params['redirect'] || namespace_redirect_path
         end
 
         # Enqueue cron job.
@@ -59,13 +66,13 @@ module Sidekiq
           if job = Sidekiq::Cron::Job.find(route_params[:name], route_params[:namespace])
             job.enque!
           end
-          redirect params['redirect'] || "#{root_path}cron/namespaces/#{route_params[:namespace]}"
+          redirect params['redirect'] || namespace_redirect_path
         end
 
         # Delete all schedules.
         app.post '/cron/namespaces/:namespace/all/delete' do
           Sidekiq::Cron::Job.all(route_params[:namespace]).each(&:destroy)
-          redirect params['redirect'] || "#{root_path}cron/namespaces/#{route_params[:namespace]}"
+          redirect params['redirect'] || namespace_redirect_path
         end
 
         # Delete schedule.
@@ -73,13 +80,13 @@ module Sidekiq
           if job = Sidekiq::Cron::Job.find(route_params[:name], route_params[:namespace])
             job.destroy
           end
-          redirect params['redirect'] || "#{root_path}cron/namespaces/#{route_params[:namespace]}"
+          redirect params['redirect'] || namespace_redirect_path
         end
 
         # Enable all jobs.
         app.post '/cron/namespaces/:namespace/all/enable' do
           Sidekiq::Cron::Job.all(route_params[:namespace]).each(&:enable!)
-          redirect params['redirect'] || "#{root_path}cron/namespaces/#{route_params[:namespace]}"
+          redirect params['redirect'] || namespace_redirect_path
         end
 
         # Enable job.
@@ -87,13 +94,13 @@ module Sidekiq
           if job = Sidekiq::Cron::Job.find(route_params[:name], route_params[:namespace])
             job.enable!
           end
-          redirect params['redirect'] || "#{root_path}cron/namespaces/#{route_params[:namespace]}"
+          redirect params['redirect'] || namespace_redirect_path
         end
 
         # Disable all jobs.
         app.post '/cron/namespaces/:namespace/all/disable' do
           Sidekiq::Cron::Job.all(route_params[:namespace]).each(&:disable!)
-          redirect params['redirect'] || "#{root_path}cron/namespaces/#{route_params[:namespace]}"
+          redirect params['redirect'] || namespace_redirect_path
         end
 
         # Disable job.
@@ -101,7 +108,7 @@ module Sidekiq
           if job = Sidekiq::Cron::Job.find(route_params[:name], route_params[:namespace])
             job.disable!
           end
-          redirect params['redirect'] || "#{root_path}cron/namespaces/#{route_params[:namespace]}"
+          redirect params['redirect'] || namespace_redirect_path
         end
       end
     end

--- a/lib/sidekiq/cron/web_extension.rb
+++ b/lib/sidekiq/cron/web_extension.rb
@@ -56,7 +56,7 @@ module Sidekiq
 
         # Enqueue cron job.
         app.post '/cron/namespaces/:namespace/jobs/:name/enque' do
-          if (job = Sidekiq::Cron::Job.find(route_params[:name], route_params[:namespace]))
+          if job = Sidekiq::Cron::Job.find(route_params[:name], route_params[:namespace])
             job.enque!
           end
           redirect params['redirect'] || "#{root_path}cron/namespaces/#{route_params[:namespace]}"
@@ -70,7 +70,7 @@ module Sidekiq
 
         # Delete schedule.
         app.post '/cron/namespaces/:namespace/jobs/:name/delete' do
-          if (job = Sidekiq::Cron::Job.find(route_params[:name], route_params[:namespace]))
+          if job = Sidekiq::Cron::Job.find(route_params[:name], route_params[:namespace])
             job.destroy
           end
           redirect params['redirect'] || "#{root_path}cron/namespaces/#{route_params[:namespace]}"
@@ -84,7 +84,7 @@ module Sidekiq
 
         # Enable job.
         app.post '/cron/namespaces/:namespace/jobs/:name/enable' do
-          if (job = Sidekiq::Cron::Job.find(route_params[:name], route_params[:namespace]))
+          if job = Sidekiq::Cron::Job.find(route_params[:name], route_params[:namespace])
             job.enable!
           end
           redirect params['redirect'] || "#{root_path}cron/namespaces/#{route_params[:namespace]}"
@@ -98,7 +98,7 @@ module Sidekiq
 
         # Disable job.
         app.post '/cron/namespaces/:namespace/jobs/:name/disable' do
-          if (job = Sidekiq::Cron::Job.find(route_params[:name], route_params[:namespace]))
+          if job = Sidekiq::Cron::Job.find(route_params[:name], route_params[:namespace])
             job.disable!
           end
           redirect params['redirect'] || "#{root_path}cron/namespaces/#{route_params[:namespace]}"


### PR DESCRIPTION
This PR addresses a redirection issue in the Sidekiq Cron web extension where redirects were not consistently pointing to namespace-specific routes. The changes ensure that after performing operations (`enqueue`, `delete`, `enable`, `disable`) on cron jobs, the user is redirected to the appropriate namespace view.