### PR TITLE
Refactor sidekiq cron configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,15 @@ second_job:
 There are multiple ways to load the jobs from a YAML file
 
 1. The gem will automatically load the jobs mentioned in `config/schedule.yml` file (it supports ERB)
-2. Load the file manually as follows:
+2. When you want to load jobs from a different filename, mention the filename in sidekiq configuration as follows:
+
+    ```ruby
+    Sidekiq::Cron.configure do |config|
+      config.cron_schedule_file = "config/users_schedule.yml"
+    end
+    ```
+
+3. Load the file manually as follows:
 
     ```ruby
     # config/initializers/sidekiq.rb

--- a/README.md
+++ b/README.md
@@ -348,15 +348,7 @@ second_job:
 There are multiple ways to load the jobs from a YAML file
 
 1. The gem will automatically load the jobs mentioned in `config/schedule.yml` file (it supports ERB)
-2. When you want to load jobs from a different filename, mention the filename in sidekiq configuration as follows:
-
-    ```ruby
-    Sidekiq::Cron.configure do |config|
-      config.cron_schedule_file = "config/users_schedule.yml"
-    end
-    ```
-
-3. Load the file manually as follows:
+2. Load the file manually as follows:
 
     ```ruby
     # config/initializers/sidekiq.rb

--- a/lib/sidekiq-cron.rb
+++ b/lib/sidekiq-cron.rb
@@ -1,2 +1,7 @@
 require "sidekiq"
 require "sidekiq/cron"
+require "sidekiq/cron/job"
+require "sidekiq/cron/namespace"
+require "sidekiq/cron/poller"
+require "sidekiq/cron/launcher"
+require "sidekiq/cron/schedule_loader"

--- a/lib/sidekiq/cron.rb
+++ b/lib/sidekiq/cron.rb
@@ -9,6 +9,10 @@ module Sidekiq
       yield(configuration) if block_given?
     end
 
+    def self.reset!
+      self.configuration = Configuration.new
+    end
+
     class Configuration
       # The default namespace is used when no namespace is specified.
       attr_accessor :default_namespace

--- a/lib/sidekiq/cron.rb
+++ b/lib/sidekiq/cron.rb
@@ -36,6 +36,10 @@ module Sidekiq
       # This value controls how many past job executions are stored.
       attr_accessor :cron_history_size
 
+      # The interval, in seconds, at which to poll for scheduled cron jobs.
+      # This determines how frequently the scheduler checks for jobs to enqueue.
+      attr_accessor :cron_poll_interval
+
       # The path to a YAML file containing multiple cron job schedules.
       # This file should use the same format as Resque-scheduler for job definitions.
       attr_accessor :cron_schedule_file
@@ -45,6 +49,7 @@ module Sidekiq
         @natural_cron_parsing_mode = :single
         @reschedule_grace_period = 60
         @cron_history_size = 10
+        @cron_poll_interval = 30
         @cron_schedule_file = 'config/schedule.yml'
       end
 

--- a/lib/sidekiq/cron.rb
+++ b/lib/sidekiq/cron.rb
@@ -33,10 +33,15 @@ module Sidekiq
       # jobs that missed their schedules during the deployment. E.g., jobs that run once a day.
       attr_accessor :reschedule_grace_period
 
+      # The maximum number of recent cron job execution histories to retain.
+      # This value controls how many past job executions are stored.
+      attr_accessor :cron_history_size
+
       def initialize
         @default_namespace = 'default'
         @natural_cron_parsing_mode = :single
         @reschedule_grace_period = 60
+        @cron_history_size = 10
       end
 
       def natural_cron_parsing_mode=(mode)

--- a/lib/sidekiq/cron.rb
+++ b/lib/sidekiq/cron.rb
@@ -2,7 +2,6 @@ require "sidekiq/cron/job"
 require "sidekiq/cron/namespace"
 require "sidekiq/cron/poller"
 require "sidekiq/cron/launcher"
-require "sidekiq/cron/schedule_loader"
 
 module Sidekiq
   module Cron
@@ -37,11 +36,16 @@ module Sidekiq
       # This value controls how many past job executions are stored.
       attr_accessor :cron_history_size
 
+      # The path to a YAML file containing multiple cron job schedules.
+      # This file should use the same format as Resque-scheduler for job definitions.
+      attr_accessor :cron_schedule_file
+
       def initialize
         @default_namespace = 'default'
         @natural_cron_parsing_mode = :single
         @reschedule_grace_period = 60
         @cron_history_size = 10
+        @cron_schedule_file = 'config/schedule.yml'
       end
 
       def natural_cron_parsing_mode=(mode)

--- a/lib/sidekiq/cron.rb
+++ b/lib/sidekiq/cron.rb
@@ -1,8 +1,3 @@
-require "sidekiq/cron/job"
-require "sidekiq/cron/namespace"
-require "sidekiq/cron/poller"
-require "sidekiq/cron/launcher"
-
 module Sidekiq
   module Cron
     class << self

--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -4,8 +4,8 @@ require 'fugit'
 require 'cronex'
 require 'globalid'
 require 'sidekiq'
+require 'sidekiq/cron'
 require 'sidekiq/cron/support'
-require 'sidekiq/options'
 
 module Sidekiq
   module Cron

--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -503,7 +503,7 @@ module Sidekiq
           enqueued: @last_enqueue_time
         }
 
-        @history_size ||= (Sidekiq::Options[:cron_history_size] || 10).to_i - 1
+        @history_size ||= Sidekiq::Cron.configuration.cron_history_size.to_i - 1
         Sidekiq.redis do |conn|
           conn.lpush jid_history_key,
                      Sidekiq.dump_json(jid_history)

--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -3,8 +3,6 @@
 require 'fugit'
 require 'cronex'
 require 'globalid'
-require 'sidekiq'
-require 'sidekiq/cron'
 require 'sidekiq/cron/support'
 
 module Sidekiq

--- a/lib/sidekiq/cron/launcher.rb
+++ b/lib/sidekiq/cron/launcher.rb
@@ -8,14 +8,13 @@ require 'sidekiq/cron/poller'
 module Sidekiq
   module Cron
     module Launcher
-      DEFAULT_POLL_INTERVAL = 30
 
       # Add cron poller to launcher.
       attr_reader :cron_poller
 
       # Add cron poller and execute normal initialize of Sidekiq launcher.
       def initialize(config, **kwargs)
-        config[:cron_poll_interval] = DEFAULT_POLL_INTERVAL if config[:cron_poll_interval].nil?
+        config[:cron_poll_interval] = Sidekiq::Cron.configuration.cron_poll_interval.to_i
 
         @cron_poller = Sidekiq::Cron::Poller.new(config) if config[:cron_poll_interval] > 0
         super

--- a/lib/sidekiq/cron/launcher.rb
+++ b/lib/sidekiq/cron/launcher.rb
@@ -1,4 +1,3 @@
-require 'sidekiq/cron'
 require 'sidekiq/cron/poller'
 
 # For Cron we need to add some methods to Launcher

--- a/lib/sidekiq/cron/launcher.rb
+++ b/lib/sidekiq/cron/launcher.rb
@@ -1,5 +1,3 @@
-require 'sidekiq/cron/poller'
-
 # For Cron we need to add some methods to Launcher
 # so look at the code below.
 #

--- a/lib/sidekiq/cron/launcher.rb
+++ b/lib/sidekiq/cron/launcher.rb
@@ -1,3 +1,4 @@
+require 'sidekiq/cron'
 require 'sidekiq/cron/poller'
 
 # For Cron we need to add some methods to Launcher

--- a/lib/sidekiq/cron/namespace.rb
+++ b/lib/sidekiq/cron/namespace.rb
@@ -1,5 +1,3 @@
-require 'sidekiq'
-
 module Sidekiq
   module Cron
     class Namespace

--- a/lib/sidekiq/cron/poller.rb
+++ b/lib/sidekiq/cron/poller.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'sidekiq'
-require 'sidekiq/cron'
 require 'sidekiq/scheduled'
 require 'sidekiq/options'
 

--- a/lib/sidekiq/cron/schedule_loader.rb
+++ b/lib/sidekiq/cron/schedule_loader.rb
@@ -1,7 +1,3 @@
-require 'sidekiq'
-require 'sidekiq/cron'
-require 'sidekiq/cron/job'
-
 Sidekiq.configure_server do |config|
   schedule_file = Sidekiq::Cron.configuration.cron_schedule_file
 

--- a/lib/sidekiq/cron/schedule_loader.rb
+++ b/lib/sidekiq/cron/schedule_loader.rb
@@ -1,9 +1,9 @@
 require 'sidekiq'
+require 'sidekiq/cron'
 require 'sidekiq/cron/job'
-require 'sidekiq/options'
 
 Sidekiq.configure_server do |config|
-  schedule_file = Sidekiq::Options[:cron_schedule_file] || 'config/schedule.yml'
+  schedule_file = Sidekiq::Cron.configuration.cron_schedule_file
 
   if File.exist?(schedule_file)
     config.on(:startup) do

--- a/test/unit/job_test.rb
+++ b/test/unit/job_test.rb
@@ -5,6 +5,8 @@ require "./test/models/person"
 
 describe "Cron Job" do
   before do
+    Sidekiq::Cron.reset!
+
     # Clear all previous saved data from Redis.
     Sidekiq.redis do |conn|
       conn.keys("cron_job*").each do |key|

--- a/test/unit/launcher_test.rb
+++ b/test/unit/launcher_test.rb
@@ -3,7 +3,7 @@ require './test/test_helper'
 describe 'Cron launcher' do
   describe 'initialization' do
     before do
-      Sidekiq::Cron.configure
+      Sidekiq::Cron.reset!
     end
 
     it 'initializes poller with default poll interval when not configured' do

--- a/test/unit/launcher_test.rb
+++ b/test/unit/launcher_test.rb
@@ -3,7 +3,7 @@ require './test/test_helper'
 describe 'Cron launcher' do
   describe 'initialization' do
     before do
-      Sidekiq::Cron.configuration.cron_poll_interval = 30
+      Sidekiq::Cron.configure
     end
 
     it 'initializes poller with default poll interval when not configured' do

--- a/test/unit/launcher_test.rb
+++ b/test/unit/launcher_test.rb
@@ -2,6 +2,10 @@ require './test/test_helper'
 
 describe 'Cron launcher' do
   describe 'initialization' do
+    before do
+      Sidekiq::Cron.configuration.cron_poll_interval = 30
+    end
+
     it 'initializes poller with default poll interval when not configured' do
       Sidekiq::Cron::Poller.expects(:new).with do |options|
         assert_equal 30, options[:cron_poll_interval]

--- a/test/unit/launcher_test.rb
+++ b/test/unit/launcher_test.rb
@@ -2,13 +2,9 @@ require './test/test_helper'
 
 describe 'Cron launcher' do
   describe 'initialization' do
-    before do
-      Sidekiq::Options[:cron_poll_interval] = nil
-    end
-
     it 'initializes poller with default poll interval when not configured' do
       Sidekiq::Cron::Poller.expects(:new).with do |options|
-        assert_equal Sidekiq::Cron::Launcher::DEFAULT_POLL_INTERVAL, options[:cron_poll_interval]
+        assert_equal 30, options[:cron_poll_interval]
       end
 
       Sidekiq::Launcher.new(Sidekiq::Options.config)
@@ -19,14 +15,14 @@ describe 'Cron launcher' do
         assert_equal 99, options[:cron_poll_interval]
       end
 
-      Sidekiq::Options[:cron_poll_interval] = 99
+      Sidekiq::Cron.configuration.cron_poll_interval = 99
       Sidekiq::Launcher.new(Sidekiq::Options.config)
     end
 
     it 'does not initialize the poller when interval is 0' do
       Sidekiq::Cron::Poller.expects(:new).never
 
-      Sidekiq::Options[:cron_poll_interval] = 0
+      Sidekiq::Cron.configuration.cron_poll_interval = 0
       Sidekiq::Launcher.new(Sidekiq::Options.config)
     end
   end

--- a/test/unit/launcher_test.rb
+++ b/test/unit/launcher_test.rb
@@ -8,7 +8,7 @@ describe 'Cron launcher' do
 
     it 'initializes poller with default poll interval when not configured' do
       Sidekiq::Cron::Poller.expects(:new).with do |options|
-        assert_equal 30, options[:cron_poll_interval]
+        assert_equal Sidekiq::Cron.configuration.cron_poll_interval, options[:cron_poll_interval]
       end
 
       Sidekiq::Launcher.new(Sidekiq::Options.config)
@@ -16,7 +16,7 @@ describe 'Cron launcher' do
 
     it 'initializes poller with the configured poll interval' do
       Sidekiq::Cron::Poller.expects(:new).with do |options|
-        assert_equal 99, options[:cron_poll_interval]
+        assert_equal Sidekiq::Cron.configuration.cron_poll_interval, options[:cron_poll_interval]
       end
 
       Sidekiq::Cron.configuration.cron_poll_interval = 99

--- a/test/unit/namespace_test.rb
+++ b/test/unit/namespace_test.rb
@@ -4,6 +4,8 @@ require './test/test_helper'
 
 describe 'Namespaces' do
   before do
+    Sidekiq::Cron.reset!
+
     # Clear all previous saved data from Redis.
     Sidekiq.redis do |conn|
       conn.keys("cron_job*").each do |key|

--- a/test/unit/poller_test.rb
+++ b/test/unit/poller_test.rb
@@ -14,7 +14,10 @@ end
 
 describe 'Cron Poller' do
   # Clear all previous saved data from Redis.
-  before { Sidekiq.redis(&:flushdb) }
+  before do
+    Sidekiq::Cron.reset!
+    Sidekiq.redis(&:flushdb)
+  end
 
   let(:args) do
     {

--- a/test/unit/schedule_loader_test.rb
+++ b/test/unit/schedule_loader_test.rb
@@ -2,6 +2,7 @@ require './test/test_helper'
 
 describe 'ScheduleLoader' do
   before do
+    Sidekiq::Cron.reset!
     Sidekiq::Options[:lifecycle_events][:startup].clear
   end
 

--- a/test/unit/schedule_loader_test.rb
+++ b/test/unit/schedule_loader_test.rb
@@ -7,7 +7,7 @@ describe 'ScheduleLoader' do
 
   describe 'Schedule is defined in hash' do
     before do
-      Sidekiq::Options[:cron_schedule_file] = 'test/unit/fixtures/schedule_hash.yml'
+      Sidekiq::Cron.configuration.cron_schedule_file = 'test/unit/fixtures/schedule_hash.yml'
       load 'sidekiq/cron/schedule_loader.rb'
     end
 
@@ -19,7 +19,7 @@ describe 'ScheduleLoader' do
 
   describe 'Schedule is defined in array' do
     before do
-      Sidekiq::Options[:cron_schedule_file] = 'test/unit/fixtures/schedule_array.yml'
+      Sidekiq::Cron.configuration.cron_schedule_file = 'test/unit/fixtures/schedule_array.yml'
       load 'sidekiq/cron/schedule_loader.rb'
     end
 
@@ -31,7 +31,7 @@ describe 'ScheduleLoader' do
 
   describe 'Schedule is not defined in hash nor array' do
     before do
-      Sidekiq::Options[:cron_schedule_file] = 'test/unit/fixtures/schedule_string.yml'
+      Sidekiq::Cron.configuration.cron_schedule_file = 'test/unit/fixtures/schedule_string.yml'
       load 'sidekiq/cron/schedule_loader.rb'
     end
 
@@ -45,7 +45,7 @@ describe 'ScheduleLoader' do
 
   describe 'Schedule is defined using ERB' do
     it 'properly parses the schedule file' do
-      Sidekiq::Options[:cron_schedule_file] = 'test/unit/fixtures/schedule_erb.yml'
+      Sidekiq::Cron.configuration.cron_schedule_file = 'test/unit/fixtures/schedule_erb.yml'
       load 'sidekiq/cron/schedule_loader.rb'
 
       Sidekiq::Options[:lifecycle_events][:startup].first.call

--- a/test/unit/web_extension_test.rb
+++ b/test/unit/web_extension_test.rb
@@ -12,6 +12,7 @@ describe 'Cron web' do
   before do
     env 'rack.session', { csrf: TOKEN }
     env 'HTTP_X_CSRF_TOKEN', TOKEN
+    Sidekiq::Cron.reset!
     Sidekiq.redis { |c| c.flushdb }
   end
 

--- a/test/unit/web_extension_test.rb
+++ b/test/unit/web_extension_test.rb
@@ -12,7 +12,6 @@ describe 'Cron web' do
   before do
     env 'rack.session', { csrf: TOKEN }
     env 'HTTP_X_CSRF_TOKEN', TOKEN
-    Sidekiq::Cron.reset!
     Sidekiq.redis { |c| c.flushdb }
   end
 


### PR DESCRIPTION
This PR refactors the configuration management in `sidekiq-cron` by moving `cron_poll_interval` and other related options from `Sidekiq::Options` to the `Sidekiq::Cron.configuration`. This change improves separation of concerns by allowing `sidekiq-cron` to manage its own settings independently from sidekiq's core options.