### PR TITLE
Add `retry` job configuration option to set sidekiq retry job option

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ gem "sidekiq-cron"
   'namespace' => 'YourNamespace', # groups jobs together in a namespace (Default value is 'default'),
   'source' => 'dynamic', # source of the job, `schedule`/`dynamic` (default: `dynamic`)
   'queue' => 'name of queue',
+  'retry' => '5', # Sidekiq (not supported by ActiveJob) number of retries, or false to discard on first failure
   'args' => '[Array or Hash] of arguments which will be passed to perform method',
   'date_as_argument' => true, # add the time of execution as last argument of the perform method
   'active_job' => true,  # enqueue job through Active Job interface

--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -61,6 +61,7 @@ module Sidekiq
           @message = args["message"]
           message_data = Sidekiq.load_json(@message) || {}
           @queue = message_data['queue'] || "default"
+          @retry = message_data['retry']
         elsif @klass
           message_data = {
             "class" => @klass.to_s,
@@ -72,12 +73,18 @@ module Sidekiq
           klass_data = get_job_class_options(@klass)
           message_data = klass_data.merge(message_data)
 
-          # Override queue if set in config,
+          # Override queue and retry if set in config,
           # only if message is hash - can be string (dumped JSON).
           if args['queue']
             @queue = message_data['queue'] = args['queue']
           else
             @queue = message_data['queue'] || "default"
+          end
+
+          if args['retry'] != nil
+            @retry = message_data['retry'] = args['retry']
+          else
+            @retry = message_data['retry']
           end
 
           @message = message_data
@@ -166,7 +173,7 @@ module Sidekiq
       end
 
       def enqueue_sidekiq_worker(klass_const)
-        klass_const.set(queue: queue_name_with_prefix).perform_async(*enqueue_args)
+        klass_const.set(queue: queue_name_with_prefix, retry: @retry).perform_async(*enqueue_args)
       end
 
       # Sidekiq worker message.
@@ -422,6 +429,7 @@ module Sidekiq
           active_job: @active_job ? "1" : "0",
           queue_name_prefix: @active_job_queue_name_prefix,
           queue_name_delimiter: @active_job_queue_name_delimiter,
+          retry: @retry.nil? || @retry.is_a?(Numeric) ? @retry : @retry.to_s,
           last_enqueue_time: serialized_last_enqueue_time,
           symbolize_args: symbolize_args? ? "1" : "0",
         }

--- a/test/unit/job_test.rb
+++ b/test/unit/job_test.rb
@@ -287,6 +287,23 @@ describe "Cron Job" do
                                  "args"=>[]}
     end
 
+    it "be initialized with 'class' and overwrite retry by settings" do
+      job = Sidekiq::Cron::Job.new('class' => CronTestClassWithQueue, retry: 5)
+
+      assert_equal job.message, {"retry"=>5,
+                                 "queue"=>:super,
+                                 "backtrace"=>true,
+                                 "class"=>"CronTestClassWithQueue",
+                                 "args"=>[]}
+
+      job = Sidekiq::Cron::Job.new('class' => CronTestClass, retry: false)
+
+      assert_equal job.message, {"retry"=>false,
+                                 "queue"=>"default",
+                                 "class"=>"CronTestClass",
+                                 "args"=>[]}
+    end
+
     it "be initialized with 'class' and date_as_argument" do
       job = Sidekiq::Cron::Job.new('class' => 'CronTestClassWithQueue', "date_as_argument" => true)
 
@@ -500,6 +517,30 @@ describe "Cron Job" do
         "retry" => false,
         "backtrace"=>true,
         "queue" => "super_queue",
+        "class" => "CronTestClassWithQueue",
+        "args"  => [{:foo=>"bar"}]
+      }
+      assert_equal @job.sidekiq_worker_message, payload
+    end
+  end
+
+  describe '#sidekiq_worker_message settings overwrite retry name' do
+    before do
+      @args = {
+        name:  'Test',
+        cron:  '* * * * *',
+        retry: 5,
+        klass: 'CronTestClassWithQueue',
+        args:  { foo: 'bar' }
+      }
+      @job = Sidekiq::Cron::Job.new(@args)
+    end
+
+    it 'should return valid payload for Sidekiq::Client with overwrite retry' do
+      payload = {
+        "retry" => 5,
+        "backtrace" => true,
+        "queue" => :super,
         "class" => "CronTestClassWithQueue",
         "args"  => [{:foo=>"bar"}]
       }


### PR DESCRIPTION
This option isn't supported by ActiveJob, which requires retry options to be set at the job class level (via the `retry_on` method) rather at the job instance level.

#### References:
 * Closes #496
 * https://github.com/sidekiq/sidekiq/wiki/Error-Handling#configuration