### PR TITLE
Fix detection of ActiveJob

### DIFF
--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -147,7 +147,7 @@ module Sidekiq
       end
 
       def is_active_job?(klass = nil)
-        @active_job || defined?(ActiveJob::Base) && (klass || Sidekiq::Cron::Support.constantize(@klass.to_s)) < ActiveJob::Base
+        @active_job || defined?(::ActiveJob::Base) && (klass || Sidekiq::Cron::Support.constantize(@klass.to_s)) < ::ActiveJob::Base
       rescue NameError
         false
       end
@@ -181,16 +181,16 @@ module Sidekiq
 
         if !"#{@active_job_queue_name_delimiter}".empty?
           queue_name_delimiter = @active_job_queue_name_delimiter
-        elsif defined?(ActiveJob::Base) && defined?(ActiveJob::Base.queue_name_delimiter) && !ActiveJob::Base.queue_name_delimiter.empty?
-          queue_name_delimiter = ActiveJob::Base.queue_name_delimiter
+        elsif defined?(::ActiveJob::Base) && defined?(::ActiveJob::Base.queue_name_delimiter) && !::ActiveJob::Base.queue_name_delimiter.empty?
+          queue_name_delimiter = ::ActiveJob::Base.queue_name_delimiter
         else
           queue_name_delimiter = '_'
         end
 
         if !"#{@active_job_queue_name_prefix}".empty?
           queue_name = "#{@active_job_queue_name_prefix}#{queue_name_delimiter}#{@queue}"
-        elsif defined?(ActiveJob::Base) && defined?(ActiveJob::Base.queue_name_prefix) && !"#{ActiveJob::Base.queue_name_prefix}".empty?
-          queue_name = "#{ActiveJob::Base.queue_name_prefix}#{queue_name_delimiter}#{@queue}"
+        elsif defined?(::ActiveJob::Base) && defined?(::ActiveJob::Base.queue_name_prefix) && !"#{::ActiveJob::Base.queue_name_prefix}".empty?
+          queue_name = "#{::ActiveJob::Base.queue_name_prefix}#{queue_name_delimiter}#{@queue}"
         else
           queue_name = @queue
         end

--- a/test/unit/job_test.rb
+++ b/test/unit/job_test.rb
@@ -510,7 +510,7 @@ describe "Cron Job" do
   describe '#active_job_message' do
     before do
       SecureRandom.stubs(:uuid).returns('XYZ')
-      ActiveJob::Base.queue_name_prefix = ''
+      ::ActiveJob::Base.queue_name_prefix = ''
 
       @args = {
         name:  'Test',
@@ -559,7 +559,7 @@ describe "Cron Job" do
   describe '#active_job_message - unknown Active Job Worker class' do
     before do
       SecureRandom.stubs(:uuid).returns('XYZ')
-      ActiveJob::Base.queue_name_prefix = ''
+      ::ActiveJob::Base.queue_name_prefix = ''
 
       @args = {
         name:  'Test',
@@ -593,7 +593,7 @@ describe "Cron Job" do
   describe '#active_job_message with symbolize_args (hash)' do
     before do
       SecureRandom.stubs(:uuid).returns('XYZ')
-      ActiveJob::Base.queue_name_prefix = ''
+      ::ActiveJob::Base.queue_name_prefix = ''
 
       @args = {
         name:  'Test',
@@ -627,7 +627,7 @@ describe "Cron Job" do
   describe '#active_job_message with symbolize_args (array)' do
     before do
       SecureRandom.stubs(:uuid).returns('XYZ')
-      ActiveJob::Base.queue_name_prefix = ''
+      ::ActiveJob::Base.queue_name_prefix = ''
 
       @args = {
         name:  'Test',
@@ -661,7 +661,7 @@ describe "Cron Job" do
   describe '#active_job_message with queue_name_prefix' do
     before do
       SecureRandom.stubs(:uuid).returns('XYZ')
-      ActiveJob::Base.queue_name_prefix = "prefix"
+      ::ActiveJob::Base.queue_name_prefix = "prefix"
 
       @args = {
         name:  'Test',


### PR DESCRIPTION
In https://github.com/sidekiq/sidekiq/commit/7e27a3fbfd3163fd58a17fef8ad6594b92bb3a6c (released in Sidekiq v7.3.3+) Sidekiq introduced the module `Sidekiq::ActiveJob`.

Any reference to `ActiveJob` within `Sidekiq::Cron` therefore does not get resolved to `::ActiveJob`, but to `::Sidekiq::ActiveJob`, thereby breaking `sidekiq-cron`.

We fix this by applying absolute namespacing to references to `ActiveJob`.