### PR TITLE
fix: Add quotes to Japanese translations containing multi-byte symbols

### DIFF
--- a/lib/sidekiq/cron/locales/ja.yml
+++ b/lib/sidekiq/cron/locales/ja.yml
@@ -1,8 +1,8 @@
 ja:
-  AreYouSureDeleteCronJob: 本当に%{job}のcronジョブを削除しますか？
-  AreYouSureDeleteCronJobs: 本当にすべてのcronジョブを削除しますか？
-  AreYouSureEnqueueCronJob: %{job} の クロン ジョブをキューに入れてもよろしいですか？
-  AreYouSureEnqueueCronJobs: すべての クロン ジョブをキューに入れてもよろしいですか？
+  AreYouSureDeleteCronJob: "本当に%{job}のcronジョブを削除しますか？"
+  AreYouSureDeleteCronJobs: "本当にすべてのcronジョブを削除しますか？"
+  AreYouSureEnqueueCronJob: "%{job} の クロン ジョブをキューに入れてもよろしいですか？"
+  AreYouSureEnqueueCronJobs: "すべての クロン ジョブをキューに入れてもよろしいですか？"
   Cron: Cron
   CronJobs: Cronジョブ
   CronString: Cron


### PR DESCRIPTION
## Description

- Enclose Japanese translation strings with double quotes to prevent YAML parse errors
- Double quotes are necessary when strings contain multi-byte symbols like `？`
- Fixes the "found character that cannot start any token" error

Resolves https://github.com/sidekiq-cron/sidekiq-cron/issues/514

## Screenshot

<img width="1278" alt="スクリーンショット 2024-11-12 16 20 25" src="https://github.com/user-attachments/assets/55afad18-324f-4535-8d12-28eb42f37e12">
