### PR TITLE
Fix usage of ActiveJob::Base.queue_name

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ gemspec
 
 # To test different Sidekiq versions
 gem "sidekiq", ENV.fetch("SIDEKIQ_VERSION", ">= 6")
+gem "activejob", ENV.fetch("ACTIVE_JOB_VERSION", "~> 7")

--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -70,7 +70,7 @@ module Sidekiq
 
           # Get right data for message,
           # only if message wasn't specified before.
-          klass_data = get_job_class_options(@klass)
+          klass_data = get_job_options(@klass, @args)
           message_data = klass_data.merge(message_data)
 
           # Override queue and retry if set in config,
@@ -793,7 +793,7 @@ module Sidekiq
         end
       end
 
-      def get_job_class_options(klass)
+      def get_job_options(klass, args)
         klass = klass.is_a?(Class) ? klass : begin
           Sidekiq::Cron::Support.constantize(klass)
         rescue NameError
@@ -804,7 +804,9 @@ module Sidekiq
           # Unknown class
           {"queue"=>"default"}
         elsif is_active_job?(klass)
-          {"queue"=>klass.queue_name}
+          job = klass.new(args)
+
+          {"queue"=>job.queue_name}
         else
           klass.get_sidekiq_options
         end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,33 +16,19 @@ end
 require "minitest/autorun"
 require "rack/test"
 require 'mocha/minitest'
+require 'active_job'
 require 'sidekiq'
 require 'sidekiq/web'
 require "sidekiq/cli"
 require 'sidekiq-cron'
 require 'sidekiq/cron/web'
 
+ActiveJob::Base.queue_adapter = :sidekiq
+
 Sidekiq.logger.level = Logger::ERROR
 Sidekiq.configure_client do |config|
   config.redis = { url: ENV['REDIS_URL'] || 'redis://0.0.0.0:6379' }
 end
-
-# Workaround: We need to define this class, so the actual adapter can remove the constant
-# See: https://github.com/sidekiq/sidekiq/pull/6474
-module ActiveJob
-  module QueueAdapters
-    class SidekiqAdapter; end
-  end
-end
-
-# In https://github.com/sidekiq/sidekiq/commit/7e27a3fbfd3163fd58a17fef8ad6594b92bb3a6c
-# (released in Sidekiq v7.3.3+) Sidekiq introduced the module `Sidekiq::ActiveJob`.
-# Any reference to `ActiveJob` within `Sidekiq::Cron` therefore does not
-# get resolved to `::ActiveJob`, but to `::Sidekiq::ActiveJob`.
-#
-# By loading the adapter code here, we ensure that tests break unless `::ActiveJob`
-# is used explicitly.
-require 'active_job/queue_adapters/sidekiq_adapter' if Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new("7.3.3")
 
 # For testing symbolize args
 class Hash
@@ -69,54 +55,16 @@ class CronTestClassWithQueue
   end
 end
 
-module ActiveJob
-  class Base
-    attr_accessor *%i[job_class provider_job_id arguments]
-
-    def initialize
-      yield self if block_given?
-      self.provider_job_id ||= SecureRandom.hex(12)
-    end
-
-    def self.queue_name
-      @queue_name || "default"
-    end
-
-    def self.queue_as(name)
-      @queue_name = name
-    end
-
-    def self.queue_name_prefix
-      @queue_name_prefix
-    end
-
-    def self.queue_name_prefix=(queue_name_prefix)
-      @queue_name_prefix = queue_name_prefix
-    end
-
-    def self.set(options)
-      @queue_name = options['queue'] || queue_name
-
-      self
-    end
-
-    def try(method, *args, &block)
-      send method, *args, &block if respond_to? method
-    end
-
-    def self.perform_later(*args)
-      new do |instance|
-        instance.job_class = self.class.name
-        instance.queue_name = self.class.queue_name
-        instance.arguments = [*args]
-      end
-    end
-  end
-end
-
 class ActiveJobCronTestClass < ::ActiveJob::Base
+  def perform(*)
+    nil
+  end
 end
 
 class ActiveJobCronTestClassWithQueue < ::ActiveJob::Base
   queue_as :super
+
+  def perform(*)
+    nil
+  end
 end


### PR DESCRIPTION
In `activejob` the class method `MyJob.queue_name` returns a `Proc`. To obtain the actual queue name, we need to invoke the method on an instance of the job class, e.g. `MyJob.new.queue_name`.

The test suite was unable to detect this problem because a mocked version of the `ActiveJob::Base` class was used which did not act in the same way as the actual `activejob` gem.

We fix this by testing against the actual `activejob` gem.

Fixes #512.