### PR TITLE
Unify with the word `cron` at Japanese

### DIFF
--- a/lib/sidekiq/cron/locales/ja.yml
+++ b/lib/sidekiq/cron/locales/ja.yml
@@ -1,8 +1,8 @@
 ja:
   AreYouSureDeleteCronJob: "本当に%{job}のcronジョブを削除しますか？"
   AreYouSureDeleteCronJobs: "本当にすべてのcronジョブを削除しますか？"
-  AreYouSureEnqueueCronJob: "%{job} の クロン ジョブをキューに入れてもよろしいですか？"
-  AreYouSureEnqueueCronJobs: "すべての クロン ジョブをキューに入れてもよろしいですか？"
+  AreYouSureEnqueueCronJob: "%{job} の cronジョブをキューに入れてもよろしいですか？"
+  AreYouSureEnqueueCronJobs: "すべての cronジョブをキューに入れてもよろしいですか？"
   Cron: Cron
   CronJobs: Cronジョブ
   CronString: Cron


### PR DESCRIPTION
The translated text contains the words `cron` and `クロン` mixed together. Since it works with `cron`, use `cron`.