### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3", "3.4", "ruby-head"]
+        ruby: ["3.2", "3.3", "3.4", "ruby-head"]
         sidekiq: ["~> 6", "~> 7"]
     services:
       redis:

--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,4 @@ gemspec
 gem "sidekiq", ENV.fetch("SIDEKIQ_VERSION", ">= 6")
 
 # To test different Active Job versions
-gem "activejob", ENV.fetch("ACTIVE_JOB_VERSION", "~> 7")
+gem "rails", ENV.fetch("ACTIVE_JOB_VERSION", "~> 7")

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,6 +25,8 @@ require 'sidekiq/cron/web'
 require './test/support/classes'
 require './test/support/helpers'
 
+require "rails/engine/railties"
+require "sidekiq/rails"
 ActiveJob::Base.queue_adapter = :sidekiq
 
 Sidekiq.logger.level = Logger::ERROR


### PR DESCRIPTION
This fixes CI for Sidekiq 7 where otherwise `Sidekiq::ActiveJob::Wrapper` would not be defined.