### PR TITLE
Add support for Sidekiq v8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3", "3.4", "ruby-head"]
+        ruby: ["3.2", "3.3", "3.4", "ruby-head"]
         sidekiq: ["~> 6", "~> 7"]
     services:
       redis:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,20 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ["3.2", "3.3", "3.4", "ruby-head"]
-        sidekiq: ["~> 6", "~> 7"]
+        sidekiq: ["~> 6", "~> 7", "~> 8"]
+        include:
+          - ruby: "2.7"
+            sidekiq: "~> 6"
+          - ruby: "2.7"
+            sidekiq: "~> 7"
+          - ruby: "3.0"
+            sidekiq: "~> 6"
+          - ruby: "3.0"
+            sidekiq: "~> 7"
+          - ruby: "3.1"
+            sidekiq: "~> 6"
+          - ruby: "3.1"
+            sidekiq: "~> 7"
     services:
       redis:
         image: redis

--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,4 @@ gemspec
 gem "sidekiq", ENV.fetch("SIDEKIQ_VERSION", ">= 6")
 
 # To test different Active Job versions
-gem "activejob", ENV.fetch("ACTIVE_JOB_VERSION", "~> 7")
+gem "rails", ENV.fetch("ACTIVE_JOB_VERSION", "~> 7")

--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,5 @@ gemspec
 # To test different Sidekiq versions
 gem "sidekiq", ENV.fetch("SIDEKIQ_VERSION", ">= 6")
 
-# To test different Active Job versions
-gem "rails", ENV.fetch("ACTIVE_JOB_VERSION", "~> 7")
+# To test different Rails versions
+gem "rails", ENV.fetch("RAILS_VERSION", "~> 7")

--- a/lib/sidekiq/cron/views/cron.erb
+++ b/lib/sidekiq/cron/views/cron.erb
@@ -28,20 +28,33 @@
 </header>
 
 <!-- Namespaces -->
-<div class='row'>
-  <div class="col-sm-12 summary_bar">
-    <ul class="list-unstyled summary row">
-      <% Sidekiq::Cron::Namespace.all_with_count.sort_by { |namespace| namespace[:name] }.each do |namespace| %>
-        <li class="col-sm-1">
-          <a href="<%= root_path %>cron/namespaces/<%= namespace[:name] %>">
-            <span class="count"><%= namespace[:count] %></span>
-            <span class="desc"><%= namespace[:name] %></span>
-          </a>
-        </li>
-      <% end %>
-    </ul>
+<% if Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new("8.0.0") %>
+  <div class="cards-container">
+    <% Sidekiq::Cron::Namespace.all_with_count.sort_by { |namespace| namespace[:name] }.each do |namespace| %>
+      <article>
+        <a href="<%= root_path %>cron/namespaces/<%= namespace[:name] %>">
+          <span class="count"><%= namespace[:count] %></span>
+          <span class="desc"><%= namespace[:name] %></span>
+        </a>
+      </article>
+    <% end %>
   </div>
-</div>
+<% else %>
+  <div class='row'>
+    <div class="col-sm-12 summary_bar">
+      <ul class="list-unstyled summary row">
+        <% Sidekiq::Cron::Namespace.all_with_count.sort_by { |namespace| namespace[:name] }.each do |namespace| %>
+          <li class="col-sm-1">
+            <a href="<%= root_path %>cron/namespaces/<%= namespace[:name] %>">
+              <span class="count"><%= namespace[:count] %></span>
+              <span class="desc"><%= namespace[:name] %></span>
+            </a>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+  </div>
+<% end %>
 <!-- Namespaces -->
 
 <% if @cron_jobs.size > 0 %>

--- a/lib/sidekiq/cron/web.rb
+++ b/lib/sidekiq/cron/web.rb
@@ -3,7 +3,16 @@ require "sidekiq/cron/job"
 require "sidekiq/cron/namespace"
 
 if defined?(Sidekiq::Web)
-  if Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new('7.3.0')
+  if Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new('8.0.0')
+    Sidekiq::Web.configure do |config|
+      config.register(
+        Sidekiq::Cron::WebExtension, # Class which contains the HTTP actions, required
+        name: "cron", # the name of the extension, used to namespace assets
+        tab: "Cron", # labels(s) of the UI tabs
+        index: "cron", # index route(s) for each tab
+      )
+    end
+  elsif Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new('7.3.0')
     Sidekiq::Web.register(
       Sidekiq::Cron::WebExtension, # Class which contains the HTTP actions, required
       name: "cron", # the name of the extension, used to namespace assets

--- a/lib/sidekiq/cron/web_extension.rb
+++ b/lib/sidekiq/cron/web_extension.rb
@@ -1,24 +1,40 @@
 module Sidekiq
   module Cron
     module WebExtension
-      def self.registered(app)
-        app.settings.locales << File.join(File.expand_path("..", __FILE__), "locales")
-
-        app.helpers do
-          # This method constructs the URL for the cron jobs page within the specified namespace.
-          def namespace_redirect_path
-            "#{root_path}cron/namespaces/#{route_params[:namespace]}"
-          end
-
-          def redirect_to_previous_or_default
-            redirect params['redirect'] || namespace_redirect_path
-          end
-
-          def render_erb(view)
-            views_path = File.join(File.expand_path("..", __FILE__), "views")
-            erb(File.read(File.join(views_path, "#{view}.erb")))
+      module Helpers
+        def cron_route_params(key)
+          if Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new("8.0.0")
+            route_params(key)
+          else
+            route_params[key]
           end
         end
+        
+        # This method constructs the URL for the cron jobs page within the specified namespace.
+        def namespace_redirect_path
+          "#{root_path}cron/namespaces/#{cron_route_params(:namespace)}"
+        end
+
+        def redirect_to_previous_or_default
+          redirect params['redirect'] || namespace_redirect_path
+        end
+
+        def render_erb(view)
+          views_path = File.join(File.expand_path("..", __FILE__), "views")
+          erb(File.read(File.join(views_path, "#{view}.erb")))
+        end
+      end
+
+      def self.registered(app)
+        locales = if Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new("8.0.0")
+                    Sidekiq::Web.configure.locales
+                  else
+                    app.settings.locales
+                  end
+
+        locales << File.join(File.expand_path("..", __FILE__), "locales")
+
+        app.helpers(Helpers)
 
         # Index page.
         app.get '/cron' do
@@ -30,7 +46,7 @@ module Sidekiq
 
         # Detail page for a specific namespace.
         app.get '/cron/namespaces/:name' do
-          @current_namespace = route_params[:name]
+          @current_namespace = cron_route_params(:name)
           @cron_jobs = Sidekiq::Cron::Job.all(@current_namespace)
 
           render_erb(:cron)
@@ -38,8 +54,8 @@ module Sidekiq
 
         # Display job detail + jid history.
         app.get '/cron/namespaces/:namespace/jobs/:name' do
-          @current_namespace = route_params[:namespace]
-          @job = Sidekiq::Cron::Job.find(route_params[:name], @current_namespace)
+          @current_namespace = cron_route_params(:namespace)
+          @job = Sidekiq::Cron::Job.find(cron_route_params(:name), @current_namespace)
 
           if @job
             render_erb(:cron_show)
@@ -50,14 +66,14 @@ module Sidekiq
 
         # Enqueue all cron jobs.
         app.post '/cron/namespaces/:namespace/all/enqueue' do
-          Sidekiq::Cron::Job.all(route_params[:namespace]).each(&:enqueue!)
+          Sidekiq::Cron::Job.all(cron_route_params(:namespace)).each(&:enqueue!)
 
           redirect_to_previous_or_default
         end
 
         # Enqueue cron job.
         app.post '/cron/namespaces/:namespace/jobs/:name/enqueue' do
-          if job = Sidekiq::Cron::Job.find(route_params[:name], route_params[:namespace])
+          if job = Sidekiq::Cron::Job.find(cron_route_params(:name), cron_route_params(:namespace))
             job.enqueue!
           end
 
@@ -66,14 +82,14 @@ module Sidekiq
 
         # Delete all schedules.
         app.post '/cron/namespaces/:namespace/all/delete' do
-          Sidekiq::Cron::Job.all(route_params[:namespace]).each(&:destroy)
+          Sidekiq::Cron::Job.all(cron_route_params(:namespace)).each(&:destroy)
 
           redirect_to_previous_or_default
         end
 
         # Delete schedule.
         app.post '/cron/namespaces/:namespace/jobs/:name/delete' do
-          if job = Sidekiq::Cron::Job.find(route_params[:name], route_params[:namespace])
+          if job = Sidekiq::Cron::Job.find(cron_route_params(:name), cron_route_params(:namespace))
             job.destroy
           end
 
@@ -82,14 +98,14 @@ module Sidekiq
 
         # Enable all jobs.
         app.post '/cron/namespaces/:namespace/all/enable' do
-          Sidekiq::Cron::Job.all(route_params[:namespace]).each(&:enable!)
+          Sidekiq::Cron::Job.all(cron_route_params(:namespace)).each(&:enable!)
 
           redirect_to_previous_or_default
         end
 
         # Enable job.
         app.post '/cron/namespaces/:namespace/jobs/:name/enable' do
-          if job = Sidekiq::Cron::Job.find(route_params[:name], route_params[:namespace])
+          if job = Sidekiq::Cron::Job.find(cron_route_params(:name), cron_route_params(:namespace))
             job.enable!
           end
 
@@ -98,14 +114,14 @@ module Sidekiq
 
         # Disable all jobs.
         app.post '/cron/namespaces/:namespace/all/disable' do
-          Sidekiq::Cron::Job.all(route_params[:namespace]).each(&:disable!)
+          Sidekiq::Cron::Job.all(cron_route_params(:namespace)).each(&:disable!)
 
           redirect_to_previous_or_default
         end
 
         # Disable job.
         app.post '/cron/namespaces/:namespace/jobs/:name/disable' do
-          if job = Sidekiq::Cron::Job.find(route_params[:name], route_params[:namespace])
+          if job = Sidekiq::Cron::Job.find(cron_route_params(:name), cron_route_params(:namespace))
             job.disable!
           end
 

--- a/sidekiq-cron.gemspec
+++ b/sidekiq-cron.gemspec
@@ -33,8 +33,8 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency("minitest", "~> 5.15")
   s.add_development_dependency("mocha", "~> 2.1")
-  s.add_development_dependency("rack", "~> 2.2")
-  s.add_development_dependency("rack-test", "~> 1.1")
+  s.add_development_dependency("rack", ">= 2.2")
+  s.add_development_dependency("rack-test", ">= 1.1")
   s.add_development_dependency("rake", "~> 13.0")
   s.add_development_dependency("simplecov", "~> 0.21")
   s.add_development_dependency("simplecov-cobertura", "~> 2.1")

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,16 +17,17 @@ require 'minitest/autorun'
 require 'rack/test'
 require 'mocha/minitest'
 require 'active_job'
+require 'rails/railtie'
+require 'rails/engine/railties'
 require 'sidekiq'
 require 'sidekiq/web'
 require 'sidekiq/cli'
 require 'sidekiq-cron'
 require 'sidekiq/cron/web'
+require 'sidekiq/rails'
 require './test/support/classes'
 require './test/support/helpers'
 
-require "rails/engine/railties"
-require "sidekiq/rails"
 ActiveJob::Base.queue_adapter = :sidekiq
 
 Sidekiq.logger.level = Logger::ERROR

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,6 +25,8 @@ require 'sidekiq/cron/web'
 require './test/support/classes'
 require './test/support/helpers'
 
+require "rails/engine/railties"
+require "sidekiq/rails"
 ActiveJob::Base.queue_adapter = :sidekiq
 
 Sidekiq.logger.level = Logger::ERROR

--- a/test/unit/web_extension_test.rb
+++ b/test/unit/web_extension_test.rb
@@ -15,6 +15,14 @@ describe 'Cron web' do
 
     Sidekiq::Cron.reset!
     Sidekiq.redis(&:flushdb)
+
+    if Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new("8.0.0")
+      Sidekiq::Web.configure do |c|
+        # Remove CSRF protection
+        # See: https://github.com/sidekiq/sidekiq/blob/0a1bce30e562357e0bb60ce84d78fe5d8446bed9/test/webext_test.rb#L37
+        c.middlewares.clear
+      end
+    end
   end
 
   let(:job_name) { "TestNameOfCronJob" }


### PR DESCRIPTION
This change will make `sidekiq-cron` functionally compatible with Sidekiq v8.0.0.

Some users may take issue to the placment of the buttons on the web UI
due to `.pull-right` not working anymore. This is left to another developer
with better knowledge of web design.

![Screenshot_2025-03-06_22-22-11](https://github.com/user-attachments/assets/2ad53490-468c-4630-bf6c-640450e77a3c)

Fixes #529