### PR TITLE
Properly support Sidekiq v8 new UI

### DIFF
--- a/lib/sidekiq/cron/views/cron.erb
+++ b/lib/sidekiq/cron/views/cron.erb
@@ -1,34 +1,31 @@
-<header class='row'>
-  <div class='col-sm-5 pull-left'>
-    <h3>
+<section>
+  <header>
+    <h2>
       <%= t('CronJobs') %>
-      <small><%= @current_namespace %></small>
-    </h3>
-  </div>
-  <div class='col-sm-7 pull-right h2'>
+      <small>(<%= @current_namespace %>)</small>
+    </h2>
     <% if @cron_jobs.size > 0 %>
-      <form action="<%= root_path %>cron/namespaces/<%= @current_namespace %>/all/delete" method="post" class="pull-right">
-        <%= csrf_tag %>
-        <input class="btn btn-danger" type="submit" name="delete" value="<%= t('DeleteAll') %>" data-confirm="<%= t('AreYouSureDeleteCronJobs') %>" />
-      </form>
-      <form action="<%= root_path %>cron/namespaces/<%= @current_namespace %>/all/disable" method="post" class="pull-right">
-        <%= csrf_tag %>
-        <input class="btn btn-warn" type="submit" name="enqueue" value="<%= t('DisableAll') %>" />
-      </form>
-      <form action="<%= root_path %>cron/namespaces/<%= @current_namespace %>/all/enable" method="post" class="pull-right">
-        <%= csrf_tag %>
-        <input class="btn btn-warn" type="submit" name="enqueue" value="<%= t('EnableAll') %>" />
-      </form>
-      <form action="<%= root_path %>cron/namespaces/<%= @current_namespace %>/all/enqueue" method="post" class="pull-right">
-        <%= csrf_tag %>
-        <input class="btn btn-warn" type="submit" name="enqueue" value="<%= t('EnqueueAll') %>" data-confirm="<%= t('AreYouSureEnqueueCronJobs') %>" />
+      <form class="filter">
+        <form action="<%= root_path %>cron/namespaces/<%= @current_namespace %>/all/delete" method="post">
+          <%= csrf_tag %>
+          <input class="btn btn-danger" type="submit" name="delete" value="<%= t('DeleteAll') %>" data-confirm="<%= t('AreYouSureDeleteCronJobs') %>" />
+        </form>
+        <form action="<%= root_path %>cron/namespaces/<%= @current_namespace %>/all/disable" method="post">
+          <%= csrf_tag %>
+          <input class="btn btn-primary" type="submit" name="enqueue" value="<%= t('DisableAll') %>" />
+        </form>
+        <form action="<%= root_path %>cron/namespaces/<%= @current_namespace %>/all/enable" method="post">
+          <%= csrf_tag %>
+          <input class="btn btn-primary" type="submit" name="enqueue" value="<%= t('EnableAll') %>" />
+        </form>
+        <form action="<%= root_path %>cron/namespaces/<%= @current_namespace %>/all/enqueue" method="post">
+          <%= csrf_tag %>
+          <input class="btn btn-primary" type="submit" name="enqueue" value="<%= t('EnqueueAll') %>" data-confirm="<%= t('AreYouSureEnqueueCronJobs') %>" />
+        </form>
       </form>
     <% end %>
-  </div>
-</header>
-
-<!-- Namespaces -->
-<% if Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new("8.0.0") %>
+  </header>
+  <!-- Namespaces -->
   <div class="cards-container">
     <% Sidekiq::Cron::Namespace.all_with_count.sort_by { |namespace| namespace[:name] }.each do |namespace| %>
       <article>
@@ -39,88 +36,68 @@
       </article>
     <% end %>
   </div>
-<% else %>
-  <div class='row'>
-    <div class="col-sm-12 summary_bar">
-      <ul class="list-unstyled summary row">
-        <% Sidekiq::Cron::Namespace.all_with_count.sort_by { |namespace| namespace[:name] }.each do |namespace| %>
-          <li class="col-sm-1">
-            <a href="<%= root_path %>cron/namespaces/<%= namespace[:name] %>">
-              <span class="count"><%= namespace[:count] %></span>
-              <span class="desc"><%= namespace[:name] %></span>
-            </a>
-          </li>
-        <% end %>
-      </ul>
-    </div>
-  </div>
-<% end %>
-<!-- Namespaces -->
-
-<% if @cron_jobs.size > 0 %>
-  <table class="table table-hover table-bordered table-striped table-white">
-    <thead>
-    <tr>
-      <th><%= t('Status') %></th>
-      <th width="50%"><%= t('Name') %></th>
-      <th><%= t('CronString') %></th>
-      <th><%= t('LastEnqueued') %></th>
-      <th width="180"><%= t('Actions') %></th>
-    </tr>
-    </thead>
-
-    <tbody>
-      <% @cron_jobs.sort{ |a,b| a.sort_name <=> b.sort_name }.each do |job| %>
-        <% klass = (job.status == 'disabled') ? 'bg-danger text-muted' : '' %>
-        <% escaped_job_name = CGI.escape(job.name).gsub('+', '%20') %>
+  <!-- Namespaces -->
+  <% if @cron_jobs.size > 0 %>
+    <table class="table table-hover table-bordered table-striped table-white">
+      <thead>
         <tr>
-          <td class="<%= klass %>"><%= t job.status %></td>
-          <td class="<%= klass %>">
-            <a href="<%= root_path %>cron/namespaces/<%= job.namespace %>/jobs/<%= escaped_job_name %>" title="<%= job.description %>">
-              <b class="<%= klass %>"><%= job.name %></b>
-            </a>
-            <br/>
-            <% if job.message and job.message.to_s.size > 100 %>
-              <details>
-                <summary class="btn btn-warn btn-xs">Show message</summary>
-                <p><small><%= job.message %></small></p>
-              </details>
-            <% else %>
-              <small><%= job.message %></small>
-            <% end %>
-          </td>
-          <td class="<%= klass %>"><b><%= job.human_cron %><br/><small><%= job.cron_expression_string.gsub(" ", "&nbsp;") %></small></b></td>
-          <td class="<%= klass %>"><%= job.last_enqueue_time ? relative_time(job.last_enqueue_time) : "-" %></td>
-          <td class="<%= klass %>">
-            <% if job.status == 'enabled' %>
-              <form action="<%= root_path %>cron/namespaces/<%= job.namespace %>/jobs/<%= escaped_job_name %>/enqueue" method="post">
-                <%= csrf_tag %>
-                <input class='btn btn-warn btn-xs pull-left' type="submit" name="enqueue" value="<%= t('EnqueueNow') %>" data-confirm="<%= t('AreYouSureEnqueueCronJob', :job => job.name) %>"/>
-              </form>
-              <form action="<%= root_path %>cron/namespaces/<%= job.namespace %>/jobs/<%= escaped_job_name %>/disable" method="post">
-                <%= csrf_tag %>
-                <input class='btn btn-warn btn-xs pull-left' type="submit" name="disable" value="<%= t('Disable') %>"/>
-              </form>
-            <% else %>
-              <form action="<%= root_path %>cron/namespaces/<%= job.namespace %>/jobs/<%= escaped_job_name %>/enqueue" method="post">
-                <%= csrf_tag %>
-                <input class='btn btn-warn btn-xs pull-left' type="submit" name="enqueue" value="<%= t('EnqueueNow') %>" data-confirm="<%= t('AreYouSureEnqueueCronJob', :job => job.name) %>"/>
-              </form>
-              <form action="<%= root_path %>cron/namespaces/<%= job.namespace %>/jobs/<%= escaped_job_name %>/enable" method="post">
-                <%= csrf_tag %>
-                <input class='btn btn-warn btn-xs pull-left' type="submit" name="enable" value="<%= t('Enable') %>"/>
-              </form>
-              <form action="<%= root_path %>cron/namespaces/<%= job.namespace %>/jobs/<%= escaped_job_name %>/delete" method="post">
-                <%= csrf_tag %>
-                <input class='btn btn-xs btn-danger pull-left help-block' type="submit" name="delete" value="<%= t('Delete') %>" data-confirm="<%= t('AreYouSureDeleteCronJob', :job => job.name) %>"/>
-              </form>
-            <% end %>
-          </td>
+          <th><%= t('Status') %></th>
+          <th width="50%"><%= t('Name') %></th>
+          <th><%= t('CronString') %></th>
+          <th><%= t('LastEnqueued') %></th>
+          <th width="180"><%= t('Actions') %></th>
         </tr>
-      <% end %>
-    </tbody>
-  </table>
-<% else %>
-  <div class='alert alert-success'><%= t('NoCronJobsWereFound') %></div>
-<% end %>
-
+      </thead>
+      <tbody>
+        <% @cron_jobs.sort{ |a,b| a.sort_name <=> b.sort_name }.each do |job| %>
+          <% klass = (job.status == 'disabled') ? 'bg-danger text-muted' : '' %>
+          <% escaped_job_name = CGI.escape(job.name).gsub('+', '%20') %>
+          <tr>
+            <td class="<%= klass %>"><%= t job.status %></td>
+            <td class="<%= klass %>">
+              <a href="<%= root_path %>cron/namespaces/<%= job.namespace %>/jobs/<%= escaped_job_name %>" title="<%= job.description %>">
+                <b class="<%= klass %>"><%= job.name %></b>
+              </a>
+              <br/>
+              <% if job.message and job.message.to_s.size > 100 %>
+                <details>
+                  <p><small><%= job.message %></small></p>
+                </details>
+              <% else %>
+                <small><%= job.message %></small>
+              <% end %>
+            </td>
+            <td class="<%= klass %>"><b><%= job.human_cron %><br/>
+                <small><%= job.cron.gsub(" ", "&nbsp;") %></small></b></td>
+            <td class="<%= klass %>"><%= job.last_enqueue_time ? relative_time(job.last_enqueue_time) : "-" %></td>
+            <td class="<%= klass %>">
+              <div class="pagination" style="padding: 0px">
+                <form action="<%= root_path %>cron/namespaces/<%= job.namespace %>/jobs/<%= escaped_job_name %>/enqueue" method="post">
+                  <%= csrf_tag %>
+                  <input class='btn btn-warn' type="submit" name="enqueue" value="<%= t('EnqueueNow') %>" data-confirm="<%= t('AreYouSureEnqueueCronJob', :job => job.name) %>"/>
+                </form>
+                <% if job.status == 'enabled' %>
+                  <form action="<%= root_path %>cron/namespaces/<%= job.namespace %>/jobs/<%= escaped_job_name %>/disable" method="post">
+                    <%= csrf_tag %>
+                    <input class='btn btn-warn' type="submit" name="disable" value="<%= t('Disable') %>"/>
+                  </form>
+                <% else %>
+                  <form action="<%= root_path %>cron/namespaces/<%= job.namespace %>/jobs/<%= escaped_job_name %>/enable" method="post">
+                    <%= csrf_tag %>
+                    <input class='btn btn-warn' type="submit" name="enable" value="<%= t('Enable') %>"/>
+                  </form>
+                  <form action="<%= root_path %>cron/namespaces/<%= job.namespace %>/jobs/<%= escaped_job_name %>/delete" method="post">
+                    <%= csrf_tag %>
+                    <input class='btn btn-danger' type="submit" name="delete" value="<%= t('Delete') %>" data-confirm="<%= t('AreYouSureDeleteCronJob', :job => job.name) %>"/>
+                  </form>
+                <% end %>
+              </div>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% else %>
+    <div class='alert alert-success'><%= t('NoCronJobsWereFound') %></div>
+  <% end %>
+</section>

--- a/lib/sidekiq/cron/views/cron_show.erb
+++ b/lib/sidekiq/cron/views/cron_show.erb
@@ -1,92 +1,93 @@
-<header class="row">
-  <div class="span col-sm-5 pull-left">
-    <h3>
-      <%= "#{t('Cron')} #{t('Job')}" %>
-      <small><%= @job.name %></small>
-    </h3>
-  </div>
-  <div class="span col-sm-7 pull-right h2">
-    <% cron_job_path = "#{root_path}cron/namespaces/#{@current_namespace}/jobs/#{CGI.escape(@job.name).gsub('+', '%20')}" %>
-    <form action="<%= cron_job_path %>/enqueue?redirect=<%= cron_job_path %>" class="pull-right" method="post">
-      <%= csrf_tag %>
-      <input class="btn btn-warn pull-left" name="enqueue" type="submit" value="<%= t('EnqueueNow') %>" data-confirm="<%= t('AreYouSureEnqueueCronJob', :job => @job.name) %>" />
+<section>
+  <header>
+    <div>
+      <h2>
+        <%= "#{t('Cron')} #{t('Job')}" %>
+        <small><%= @job.name %></small>
+      </h2>
+    </div>
+    <form class="filter">
+      <% cron_job_path = "#{root_path}cron/namespaces/#{@current_namespace}/jobs/#{CGI.escape(@job.name).gsub('+', '%20')}" %>
+      <form action="<%= cron_job_path %>/enqueue?redirect=<%= cron_job_path %>"  method="post">
+        <%= csrf_tag %>
+        <input class="btn btn-primary" name="enqueue" type="submit" value="<%= t('EnqueueNow') %>" data-confirm="<%= t('AreYouSureEnqueueCronJob', :job => @job.name) %>" />
+      </form>
+      <% if @job.status == 'enabled' %>
+        <form action="<%= cron_job_path %>/disable?redirect=<%= cron_job_path %>"  method="post">
+          <%= csrf_tag %>
+          <input class="btn btn-primary" name="disable" type="submit" value="<%= t('Disable') %>" />
+        </form>
+      <% else %>
+        <form action="<%= cron_job_path %>/enable?redirect=<%= cron_job_path %>"  method="post">
+          <%= csrf_tag %>
+          <input class="btn btn-primary" name="enable" type="submit" value="<%= t('Enable') %>" />
+        </form>
+        <form action="<%= cron_job_path %>/delete" method="post">
+          <%= csrf_tag %>
+          <input class="btn btn-danger" data-confirm="<%= t('AreYouSureDeleteCronJob', :job => @job.name) %>" name="delete" type="submit" value="<%= t('Delete') %>" />
+        </form>
+      <% end %>
     </form>
-    <% if @job.status == 'enabled' %>
-      <form action="<%= cron_job_path %>/disable?redirect=<%= cron_job_path %>" class="pull-right" method="post">
-        <%= csrf_tag %>
-        <input class="btn btn-warn pull-left" name="disable" type="submit" value="<%= t('Disable') %>" />
-      </form>
-    <% else %>
-      <form action="<%= cron_job_path %>/enable?redirect=<%= cron_job_path %>" class="pull-right" method="post">
-        <%= csrf_tag %>
-        <input class="btn btn-warn pull-left" name="enable" type="submit" value="<%= t('Enable') %>" />
-      </form>
-      <form action="<%= cron_job_path %>/delete" class="pull-right" method="post">
-        <%= csrf_tag %>
-        <input class="btn btn-danger pull-left" data-confirm="<%= t('AreYouSureDeleteCronJob', :job => @job.name) %>" name="delete" type="submit" value="<%= t('Delete') %>" />
-      </form>
-    <% end %>
-  </div>
-</header>
-
-<table class="table table-bordered table-striped">
-  <tbody>
-  <tr>
-    <th><%= t 'Status' %></th>
-    <td><%= @job.status %></td>
-  </tr>
-  <tr>
-    <th><%= t 'Name' %></th>
-    <td><%= @job.name %></td>
-  </tr>
-  <tr>
-    <th><%= t 'Namespace' %></th>
-    <td><%= @job.namespace %></td>
-  </tr>
-  <tr>
-    <th><%= t 'Description' %></th>
-    <td><%= @job.description %></td>
-  </tr>
-  <tr>
-    <th><%= t 'Message' %></th>
-    <td><pre><%= @job.pretty_message %></pre></td>
-  </tr>
-  <tr>
-    <th><%= t 'Cron' %></th>
-    <td><%= @job.cron.gsub(" ", "&nbsp;") %></td>
-  </tr>
-  <tr>
-    <th><%= t 'Last enqueued' %></th>
-    <td><%= @job.last_enqueue_time ? relative_time(@job.last_enqueue_time) : "-" %></td>
-  </tr>
-  </tbody>
-</table>
-
-<header class="row">
-  <div class="col-sm-12">
-    <h4>
-      <%= t 'History' %>
-    </h4>
-  </div>
-</header>
-
-<% if @job.jid_history_from_redis.size > 0 %>
-  <table class="table table-hover table-bordered table-striped">
-    <thead>
-    <tr>
-      <th><%= t 'Enqueued' %></th>
-      <th><%= t 'JID' %></th>
-    </tr>
-    </thead>
+  </header>
+  <table class="table table-bordered table-striped">
     <tbody>
-    <% @job.jid_history_from_redis.each do |jid_history| %>
       <tr>
-        <td><%= jid_history['enqueued'] %></td>
-        <td><%= jid_history['jid'] %></td>
+        <th><%= t 'Status' %></th>
+        <td><%= @job.status %></td>
       </tr>
-    <% end %>
+      <tr>
+        <th><%= t 'Name' %></th>
+        <td><%= @job.name %></td>
+      </tr>
+      <tr>
+        <th><%= t 'Namespace' %></th>
+        <td><%= @job.namespace %></td>
+      </tr>
+      <tr>
+        <th><%= t 'Description' %></th>
+        <td><%= @job.description %></td>
+      </tr>
+      <tr>
+        <th><%= t 'Message' %></th>
+        <td>
+          <pre><%= @job.pretty_message %></pre>
+        </td>
+      </tr>
+      <tr>
+        <th><%= t 'Cron' %></th>
+        <td><%= @job.cron.gsub(" ", "&nbsp;") %></td>
+      </tr>
+      <tr>
+        <th><%= t 'Last enqueued' %></th>
+        <td><%= @job.last_enqueue_time ? relative_time(@job.last_enqueue_time) : "-" %></td>
+      </tr>
     </tbody>
   </table>
-<% else %>
-  <div class='alert alert-success'><%= t 'NoHistoryWereFound' %></div>
-<% end %>
+  <header>
+    <div>
+      <h4>
+        <%= t 'History' %>
+      </h4>
+    </div>
+  </header>
+  <% if @job.jid_history_from_redis.size > 0 %>
+    <table class="table table-hover table-bordered table-striped">
+      <thead>
+        <tr>
+          <th><%= t 'Enqueued' %></th>
+          <th><%= t 'JID' %></th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @job.jid_history_from_redis.each do |jid_history| %>
+          <tr>
+            <td><%= jid_history['enqueued'] %></td>
+            <td><%= jid_history['jid'] %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% else %>
+    <div class='alert alert-success'><%= t 'NoHistoryWereFound' %></div>
+  <% end %>
+</section>

--- a/lib/sidekiq/cron/views/legacy/cron.erb
+++ b/lib/sidekiq/cron/views/legacy/cron.erb
@@ -1,0 +1,113 @@
+<header class='row'>
+  <div class='col-sm-5 pull-left'>
+    <h3>
+      <%= t('CronJobs') %>
+      <small><%= @current_namespace %></small>
+    </h3>
+  </div>
+  <div class='col-sm-7 pull-right h2'>
+    <% if @cron_jobs.size > 0 %>
+      <form action="<%= root_path %>cron/namespaces/<%= @current_namespace %>/all/delete" method="post" class="pull-right">
+        <%= csrf_tag %>
+        <input class="btn btn-danger" type="submit" name="delete" value="<%= t('DeleteAll') %>" data-confirm="<%= t('AreYouSureDeleteCronJobs') %>" />
+      </form>
+      <form action="<%= root_path %>cron/namespaces/<%= @current_namespace %>/all/disable" method="post" class="pull-right">
+        <%= csrf_tag %>
+        <input class="btn btn-warn" type="submit" name="enqueue" value="<%= t('DisableAll') %>" />
+      </form>
+      <form action="<%= root_path %>cron/namespaces/<%= @current_namespace %>/all/enable" method="post" class="pull-right">
+        <%= csrf_tag %>
+        <input class="btn btn-warn" type="submit" name="enqueue" value="<%= t('EnableAll') %>" />
+      </form>
+      <form action="<%= root_path %>cron/namespaces/<%= @current_namespace %>/all/enqueue" method="post" class="pull-right">
+        <%= csrf_tag %>
+        <input class="btn btn-warn" type="submit" name="enqueue" value="<%= t('EnqueueAll') %>" data-confirm="<%= t('AreYouSureEnqueueCronJobs') %>" />
+      </form>
+    <% end %>
+  </div>
+</header>
+
+<!-- Namespaces -->
+<div class='row'>
+  <div class="col-sm-12 summary_bar">
+    <ul class="list-unstyled summary row">
+      <% Sidekiq::Cron::Namespace.all_with_count.sort_by { |namespace| namespace[:name] }.each do |namespace| %>
+        <li class="col-sm-1">
+          <a href="<%= root_path %>cron/namespaces/<%= namespace[:name] %>">
+            <span class="count"><%= namespace[:count] %></span>
+            <span class="desc"><%= namespace[:name] %></span>
+          </a>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+</div>
+<!-- Namespaces -->
+
+<% if @cron_jobs.size > 0 %>
+  <table class="table table-hover table-bordered table-striped table-white">
+    <thead>
+    <tr>
+      <th><%= t('Status') %></th>
+      <th width="50%"><%= t('Name') %></th>
+      <th><%= t('CronString') %></th>
+      <th><%= t('LastEnqueued') %></th>
+      <th width="180"><%= t('Actions') %></th>
+    </tr>
+    </thead>
+
+    <tbody>
+      <% @cron_jobs.sort{ |a,b| a.sort_name <=> b.sort_name }.each do |job| %>
+        <% klass = (job.status == 'disabled') ? 'bg-danger text-muted' : '' %>
+        <% escaped_job_name = CGI.escape(job.name).gsub('+', '%20') %>
+        <tr>
+          <td class="<%= klass %>"><%= t job.status %></td>
+          <td class="<%= klass %>">
+            <a href="<%= root_path %>cron/namespaces/<%= job.namespace %>/jobs/<%= escaped_job_name %>" title="<%= job.description %>">
+              <b class="<%= klass %>"><%= job.name %></b>
+            </a>
+            <br/>
+            <% if job.message and job.message.to_s.size > 100 %>
+              <details>
+                <summary class="btn btn-warn btn-xs">Show message</summary>
+                <p><small><%= job.message %></small></p>
+              </details>
+            <% else %>
+              <small><%= job.message %></small>
+            <% end %>
+          </td>
+          <td class="<%= klass %>"><b><%= job.human_cron %><br/><small><%= job.cron_expression_string.gsub(" ", "&nbsp;") %></small></b></td>
+          <td class="<%= klass %>"><%= job.last_enqueue_time ? relative_time(job.last_enqueue_time) : "-" %></td>
+          <td class="<%= klass %>">
+            <% if job.status == 'enabled' %>
+              <form action="<%= root_path %>cron/namespaces/<%= job.namespace %>/jobs/<%= escaped_job_name %>/enqueue" method="post">
+                <%= csrf_tag %>
+                <input class='btn btn-warn btn-xs pull-left' type="submit" name="enqueue" value="<%= t('EnqueueNow') %>" data-confirm="<%= t('AreYouSureEnqueueCronJob', :job => job.name) %>"/>
+              </form>
+              <form action="<%= root_path %>cron/namespaces/<%= job.namespace %>/jobs/<%= escaped_job_name %>/disable" method="post">
+                <%= csrf_tag %>
+                <input class='btn btn-warn btn-xs pull-left' type="submit" name="disable" value="<%= t('Disable') %>"/>
+              </form>
+            <% else %>
+              <form action="<%= root_path %>cron/namespaces/<%= job.namespace %>/jobs/<%= escaped_job_name %>/enqueue" method="post">
+                <%= csrf_tag %>
+                <input class='btn btn-warn btn-xs pull-left' type="submit" name="enqueue" value="<%= t('EnqueueNow') %>" data-confirm="<%= t('AreYouSureEnqueueCronJob', :job => job.name) %>"/>
+              </form>
+              <form action="<%= root_path %>cron/namespaces/<%= job.namespace %>/jobs/<%= escaped_job_name %>/enable" method="post">
+                <%= csrf_tag %>
+                <input class='btn btn-warn btn-xs pull-left' type="submit" name="enable" value="<%= t('Enable') %>"/>
+              </form>
+              <form action="<%= root_path %>cron/namespaces/<%= job.namespace %>/jobs/<%= escaped_job_name %>/delete" method="post">
+                <%= csrf_tag %>
+                <input class='btn btn-xs btn-danger pull-left help-block' type="submit" name="delete" value="<%= t('Delete') %>" data-confirm="<%= t('AreYouSureDeleteCronJob', :job => job.name) %>"/>
+              </form>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <div class='alert alert-success'><%= t('NoCronJobsWereFound') %></div>
+<% end %>
+

--- a/lib/sidekiq/cron/views/legacy/cron_show.erb
+++ b/lib/sidekiq/cron/views/legacy/cron_show.erb
@@ -1,0 +1,92 @@
+<header class="row">
+  <div class="span col-sm-5 pull-left">
+    <h3>
+      <%= "#{t('Cron')} #{t('Job')}" %>
+      <small><%= @job.name %></small>
+    </h3>
+  </div>
+  <div class="span col-sm-7 pull-right h2">
+    <% cron_job_path = "#{root_path}cron/namespaces/#{@current_namespace}/jobs/#{CGI.escape(@job.name).gsub('+', '%20')}" %>
+    <form action="<%= cron_job_path %>/enqueue?redirect=<%= cron_job_path %>" class="pull-right" method="post">
+      <%= csrf_tag %>
+      <input class="btn btn-warn pull-left" name="enqueue" type="submit" value="<%= t('EnqueueNow') %>" data-confirm="<%= t('AreYouSureEnqueueCronJob', :job => @job.name) %>" />
+    </form>
+    <% if @job.status == 'enabled' %>
+      <form action="<%= cron_job_path %>/disable?redirect=<%= cron_job_path %>" class="pull-right" method="post">
+        <%= csrf_tag %>
+        <input class="btn btn-warn pull-left" name="disable" type="submit" value="<%= t('Disable') %>" />
+      </form>
+    <% else %>
+      <form action="<%= cron_job_path %>/enable?redirect=<%= cron_job_path %>" class="pull-right" method="post">
+        <%= csrf_tag %>
+        <input class="btn btn-warn pull-left" name="enable" type="submit" value="<%= t('Enable') %>" />
+      </form>
+      <form action="<%= cron_job_path %>/delete" class="pull-right" method="post">
+        <%= csrf_tag %>
+        <input class="btn btn-danger pull-left" data-confirm="<%= t('AreYouSureDeleteCronJob', :job => @job.name) %>" name="delete" type="submit" value="<%= t('Delete') %>" />
+      </form>
+    <% end %>
+  </div>
+</header>
+
+<table class="table table-bordered table-striped">
+  <tbody>
+  <tr>
+    <th><%= t 'Status' %></th>
+    <td><%= @job.status %></td>
+  </tr>
+  <tr>
+    <th><%= t 'Name' %></th>
+    <td><%= @job.name %></td>
+  </tr>
+  <tr>
+    <th><%= t 'Namespace' %></th>
+    <td><%= @job.namespace %></td>
+  </tr>
+  <tr>
+    <th><%= t 'Description' %></th>
+    <td><%= @job.description %></td>
+  </tr>
+  <tr>
+    <th><%= t 'Message' %></th>
+    <td><pre><%= @job.pretty_message %></pre></td>
+  </tr>
+  <tr>
+    <th><%= t 'Cron' %></th>
+    <td><%= @job.cron.gsub(" ", "&nbsp;") %></td>
+  </tr>
+  <tr>
+    <th><%= t 'Last enqueued' %></th>
+    <td><%= @job.last_enqueue_time ? relative_time(@job.last_enqueue_time) : "-" %></td>
+  </tr>
+  </tbody>
+</table>
+
+<header class="row">
+  <div class="col-sm-12">
+    <h4>
+      <%= t 'History' %>
+    </h4>
+  </div>
+</header>
+
+<% if @job.jid_history_from_redis.size > 0 %>
+  <table class="table table-hover table-bordered table-striped">
+    <thead>
+    <tr>
+      <th><%= t 'Enqueued' %></th>
+      <th><%= t 'JID' %></th>
+    </tr>
+    </thead>
+    <tbody>
+    <% @job.jid_history_from_redis.each do |jid_history| %>
+      <tr>
+        <td><%= jid_history['enqueued'] %></td>
+        <td><%= jid_history['jid'] %></td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <div class='alert alert-success'><%= t 'NoHistoryWereFound' %></div>
+<% end %>

--- a/lib/sidekiq/cron/web_extension.rb
+++ b/lib/sidekiq/cron/web_extension.rb
@@ -9,7 +9,7 @@ module Sidekiq
             route_params[key]
           end
         end
-        
+
         # This method constructs the URL for the cron jobs page within the specified namespace.
         def namespace_redirect_path
           "#{root_path}cron/namespaces/#{cron_route_params(:namespace)}"
@@ -20,7 +20,8 @@ module Sidekiq
         end
 
         def render_erb(view)
-          views_path = File.join(File.expand_path("..", __FILE__), "views")
+          path = Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new("8.0.0") ? "views" : "views/legacy"
+          views_path = File.join(File.expand_path("..", __FILE__), path)
           erb(File.read(File.join(views_path, "#{view}.erb")))
         end
       end


### PR DESCRIPTION
Sidekiq v8 dropped Bootstrap from its assets, so I tried to fix the UI using the same classes used in sidekiq v8 UI, I opted to creating a new v8 folder in views, changes are too many to put conditional rendering in the current views

A more elegant solution would be defining a CSS asset for sidekiq-cron and load it when registering the extension in sidekiq.

- use separate folder for views for >= v8
- use vanilla CSS classes defined by sidekiq UI and drop Bootstrap CSS classes

# Screenshots
![image](https://github.com/user-attachments/assets/9659f76f-025e-4be3-8298-f2ec1bcd43e5)
![image](https://github.com/user-attachments/assets/1e30aa6d-14f7-4683-a031-714cc2c839b5)
![image](https://github.com/user-attachments/assets/da89a4bc-b2a7-4b46-9988-2413d089df91)



fixes #537 