### PR TITLE
Refactor constantize helper to use `Object.const_get`

### DIFF
--- a/lib/sidekiq/cron/support.rb
+++ b/lib/sidekiq/cron/support.rb
@@ -1,35 +1,10 @@
 module Sidekiq
   module Cron
     module Support
-      # Inspired by Active Support Inflector
-      def self.constantize(camel_cased_word)
-        names = camel_cased_word.split("::".freeze)
-
-        # Trigger a built-in NameError exception including the ill-formed constant in the message.
-        Object.const_get(camel_cased_word) if names.empty?
-
-        # Remove the first blank element in case of '::ClassName' notation.
-        names.shift if names.size > 1 && names.first.empty?
-
-        names.inject(Object) do |constant, name|
-          if constant == Object
-            constant.const_get(name)
-          else
-            candidate = constant.const_get(name)
-            next candidate if constant.const_defined?(name, false)
-            next candidate unless Object.const_defined?(name)
-
-            # Go down the ancestors to check if it is owned directly. The check
-            # stops when we reach Object or the end of ancestors tree.
-            constant = constant.ancestors.inject(constant) do |const, ancestor|
-              break const    if ancestor == Object
-              break ancestor if ancestor.const_defined?(name, false)
-              const
-            end
-
-            constant.const_get(name, false)
-          end
-        end
+      def self.safe_constantize(klass_name)
+        Object.const_get(klass_name)
+      rescue NameError
+        nil
       end
 
       def self.load_yaml(src)


### PR DESCRIPTION
This update simplifies the constantize helper method by utilizing `Object.const_get`. Similar changes have been made in Rails and Sidekiq, as shown in the following PR and commit:
* https://github.com/rails/rails/pull/41877
* https://github.com/sidekiq/sidekiq/commit/68f7b7fffb13162328a8bee60106065911346c99

Since `sidekiq-cron` requires Ruby 2.7 or later, we can adopt this approach as well.
