### PR TITLE
Allow testing of schedule by library consumers

### DIFF
--- a/lib/sidekiq/cron/schedule_loader.rb
+++ b/lib/sidekiq/cron/schedule_loader.rb
@@ -1,20 +1,56 @@
-Sidekiq.configure_server do |config|
-  schedule_file = Sidekiq::Cron.configuration.cron_schedule_file
+module Sidekiq
+  module Cron
+    class ScheduleLoader
+      def load_schedule
+        if schedule.is_a?(Hash)
+          Sidekiq::Cron::Job.load_from_hash!(schedule, source: "schedule")
+        elsif schedule.is_a?(Array)
+          Sidekiq::Cron::Job.load_from_array!(schedule, source: "schedule")
+        else
+          raise "Not supported schedule format. Confirm your #{schedule_file_name}"
+        end
+      end
 
-  unless File.exist?(schedule_file)
-    schedule_file.sub!(/\.yml$/, ".yaml")
-  end
+      def has_schedule_file?
+        File.exist?(schedule_file_name)
+      end
 
-  if File.exist?(schedule_file)
-    config.on(:startup) do
-      schedule = Sidekiq::Cron::Support.load_yaml(ERB.new(IO.read(schedule_file)).result)
-      if schedule.kind_of?(Hash)
-        Sidekiq::Cron::Job.load_from_hash!(schedule, source: "schedule")
-      elsif schedule.kind_of?(Array)
-        Sidekiq::Cron::Job.load_from_array!(schedule, source: "schedule")
-      else
-        raise "Not supported schedule format. Confirm your #{schedule_file}"
+      private
+
+      def schedule
+        @schedule ||= Sidekiq::Cron::Support.load_yaml(rendered_schedule_template)
+      end
+
+      def rendered_schedule_template
+        ERB.new(schedule_file_content).result
+      end
+
+      def schedule_file_content
+        IO.read(schedule_file_name)
+      end
+
+      def schedule_file_name
+        @schedule_file_name ||= yml_to_yaml_unless_file_exists(schedule_file_name_from_config)
+      end
+
+      def schedule_file_name_from_config
+        Sidekiq::Cron.configuration.cron_schedule_file
+      end
+
+      def yml_to_yaml_unless_file_exists(file_name)
+        if File.exist?(file_name)
+          file_name
+        else
+          file_name.sub(/\.yml$/, ".yaml")
+        end
       end
     end
   end
+end
+
+Sidekiq.configure_server do |config|
+  schedule_loader = Sidekiq::Cron::ScheduleLoader.new
+  break unless schedule_loader.has_schedule_file?
+
+  config.on(:startup) { schedule_loader.load_schedule }
 end


### PR DESCRIPTION
### Motivation / Background

After accidently adding a typo in a class name on the schedule, and [thankfully] having it caught in a PR, I wanted a better way to test the schedule in my project.

This Pull Request has been created because it enables the same schedule loader that runs in production to be called in a testing environment. This way, we have the ability to show that there are no configuration errors.

### Detail

This Pull Request changes the implementation of ScheduleLoader to enable consumers of the library to test their schedule in an environment where redis is running but the Sidekiq service is not (this is usual for testing environments).

As this change is purely an implementation detail, I have not added or changed any tests.

### Additional information

I have added an example of how to test projects in the readme.