### PR TITLE
Load schedule file within sidekiq callback

### DIFF
--- a/lib/sidekiq/cron/schedule_loader.rb
+++ b/lib/sidekiq/cron/schedule_loader.rb
@@ -49,8 +49,9 @@ module Sidekiq
 end
 
 Sidekiq.configure_server do |config|
-  schedule_loader = Sidekiq::Cron::ScheduleLoader.new
-  next unless schedule_loader.has_schedule_file?
-
-  config.on(:startup) { schedule_loader.load_schedule }
+  config.on(:startup) do
+    schedule_loader = Sidekiq::Cron::ScheduleLoader.new
+    next unless schedule_loader.has_schedule_file?
+    schedule_loader.load_schedule
+  end
 end


### PR DESCRIPTION
Fixes #507

I believe this is the correct implementation. It moves all schedule loading to happen on sidekiq startup which is after the initializers have ran. This means that any change to `config.cron_schedule_file` in an initializer will be respected.

**However, please consider the very real possibility that someone has created a `config/schedule.yml` file but has then blindly copied the configuration from [here](https://github.com/sidekiq-cron/sidekiq-cron/?tab=readme-ov-file#configuration). They may not not have a `config/my_schedule.yml` file but this does not currently matter as that setting is effectively ignored.**

In the above example, that person may upgrade their sidekiq-cron gem only to find that their schedule stops being loaded. As such, I think there is a decision to be made. Should we follow this implementation that is correct, or write more logic to protect anyone who has done the above? I personally think we should move forward with this approach and explain in the changelog that configs should be checked.