### PR TITLE
Fix missing default namespace if namespaces are explicitly provided

### DIFF
--- a/lib/sidekiq/cron/namespace.rb
+++ b/lib/sidekiq/cron/namespace.rb
@@ -2,25 +2,15 @@ module Sidekiq
   module Cron
     class Namespace
       def self.all
-        namespaces = Sidekiq::Cron.configuration.available_namespaces
-        return namespaces if namespaces
-
-        Sidekiq.redis do |conn|
-          namespaces = conn.keys('cron_jobs:*').collect do |key|
-            key.split(':').last
+        namespaces = Sidekiq::Cron.configuration.available_namespaces || begin
+          Sidekiq.redis do |conn|
+            conn.keys('cron_jobs:*').collect do |key|
+              key.split(':').last
+            end
           end
         end
 
-        # Adds the default namespace if not present
-        has_default = namespaces.detect do |name|
-          name == Sidekiq::Cron.configuration.default_namespace
-        end
-
-        unless has_default
-          namespaces << Sidekiq::Cron.configuration.default_namespace
-        end
-
-        namespaces
+        namespaces | [Sidekiq::Cron.configuration.default_namespace]
       end
 
       def self.all_with_count
@@ -33,11 +23,9 @@ module Sidekiq
       end
 
       def self.count(name = Sidekiq::Cron.configuration.default_namespace)
-        out = 0
         Sidekiq.redis do |conn|
-          out = conn.scard("cron_jobs:#{name}")
+          conn.scard("cron_jobs:#{name}")
         end
-        out
       end
 
       def self.available_namespaces_provided?

--- a/test/unit/namespace_test.rb
+++ b/test/unit/namespace_test.rb
@@ -33,9 +33,7 @@ describe 'Namespaces' do
       Sidekiq::Cron::Job.create(args.merge(namespace: 'namespace1'))
       Sidekiq::Cron::Job.create(args.merge(namespace: 'namespace2'))
 
-      expected = %w[default namespace1 namespace2]
-
-      assert_equal Sidekiq::Cron::Namespace.all.sort, expected
+      assert_equal %w[default namespace1 namespace2], Sidekiq::Cron::Namespace.all.sort
     end
 
     it 'uses provided namespaces list if available' do
@@ -44,9 +42,7 @@ describe 'Namespaces' do
       Sidekiq::Cron::Job.create(args.merge(namespace: 'implicit-namespace1'))
       Sidekiq::Cron::Job.create(args.merge(namespace: 'implicit-namespace2'))
 
-      expected = %w[namespace1 namespace2]
-
-      assert_equal Sidekiq::Cron::Namespace.all.sort, expected
+      assert_equal %w[default namespace1 namespace2], Sidekiq::Cron::Namespace.all.sort
     end
   end
 


### PR DESCRIPTION
Looks like a bug: currently, if `available_namespaces` is provided (e.g. `%w[namespace-1 namespace-2]`) then there's no `default_namespace` in the list.