### PR TITLE
Rework namespaces feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-- **WARNING** The default value for `available_namespaces` has changed from `nil` to `[default_namespace]`. Please refer to the [migration guude](#) for further details.
+- **WARNING** The default value for `available_namespaces` has changed from `nil` to `[default_namespace]`. Please refer to the [migration guide](https://github.com/sidekiq-cron/sidekiq-cron/blob/master/README.md#migrating-to-23) for further details.
 
 ## 2.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file.
 
+- **WARNING** The default value for `available_namespaces` has changed from `nil` to `[default_namespace]`. Please refer to the [migration guude](#) for further details.
+
 ## 2.2.0
 
 - Add support for Sidekiq v8 (https://github.com/sidekiq-cron/sidekiq-cron/pull/531, https://github.com/sidekiq-cron/sidekiq-cron/pull/538)

--- a/lib/sidekiq/cron.rb
+++ b/lib/sidekiq/cron.rb
@@ -58,7 +58,7 @@ module Sidekiq
         @cron_schedule_file = 'config/schedule.yml'
         @cron_history_size = 10
         @default_namespace = 'default'
-        @available_namespaces = nil
+        @available_namespaces = [@default_namespace]
         @natural_cron_parsing_mode = :single
         @reschedule_grace_period = 60
       end

--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -32,7 +32,7 @@ module Sidekiq
 
         default_namespace = Sidekiq::Cron.configuration.default_namespace
         @namespace = args["namespace"] || default_namespace
-        if Sidekiq::Cron::Namespace.available_namespaces_provided? && !Sidekiq::Cron::Namespace.all.include?(@namespace) && @namespace != default_namespace
+        if Sidekiq::Cron::Namespace.available_namespaces_provided? && !Sidekiq::Cron::Namespace.all.include?(@namespace)
           Sidekiq.logger.warn { "Cron Jobs - unexpected namespace #{@namespace} encountered. Assigning to default namespace." }
           @namespace = default_namespace
         end
@@ -693,7 +693,7 @@ module Sidekiq
       def self.job_keys_from_namespace(namespace = Sidekiq::Cron.configuration.default_namespace)
         Sidekiq.redis do |conn|
           if namespace == '*'
-            namespaces = Sidekiq::Cron.configuration.available_namespaces&.map { jobs_key(_1) } || conn.keys(jobs_key(namespace))
+            namespaces = Sidekiq::Cron::Namespace.all.map { jobs_key(_1) }
             namespaces.flat_map { |name| conn.smembers(name) }
           else
             conn.smembers(jobs_key(namespace))

--- a/lib/sidekiq/cron/namespace.rb
+++ b/lib/sidekiq/cron/namespace.rb
@@ -2,13 +2,16 @@ module Sidekiq
   module Cron
     class Namespace
       def self.all
-        namespaces = Sidekiq::Cron.configuration.available_namespaces || begin
-          Sidekiq.redis do |conn|
-            conn.keys('cron_jobs:*').collect do |key|
-              key.split(':').last
+        namespaces = case (available_namespaces = Sidekiq::Cron.configuration.available_namespaces)
+          when NilClass then []
+          when Array then available_namespaces
+          else
+            Sidekiq.redis do |conn|
+              conn.keys('cron_jobs:*').collect do |key|
+                key.split(':').last
+              end
             end
           end
-        end
 
         namespaces | [Sidekiq::Cron.configuration.default_namespace]
       end
@@ -29,7 +32,9 @@ module Sidekiq
       end
 
       def self.available_namespaces_provided?
-        !!Sidekiq::Cron.configuration.available_namespaces
+        available_namespaces = Sidekiq::Cron.configuration.available_namespaces
+
+        available_namespaces != nil && available_namespaces != :auto
       end
     end
   end

--- a/lib/sidekiq/cron/namespace.rb
+++ b/lib/sidekiq/cron/namespace.rb
@@ -5,12 +5,14 @@ module Sidekiq
         namespaces = case (available_namespaces = Sidekiq::Cron.configuration.available_namespaces)
           when NilClass then []
           when Array then available_namespaces
-          else
+          when :auto
             Sidekiq.redis do |conn|
               conn.keys('cron_jobs:*').collect do |key|
                 key.split(':').last
               end
             end
+          else
+            raise ArgumentError, "Unexpected value provided for `available_namespaces`: #{available_namespaces.inspect}"
           end
 
         namespaces | [Sidekiq::Cron.configuration.default_namespace]

--- a/test/unit/job_test.rb
+++ b/test/unit/job_test.rb
@@ -6,6 +6,8 @@ describe "Cron Job" do
   before do
     Sidekiq::Cron.reset!
 
+    Sidekiq::Cron.configuration.available_namespaces = :auto
+
     # Clear all previous saved data from Redis.
     Sidekiq.redis do |conn|
       conn.keys("cron_job*").each do |key|
@@ -1288,7 +1290,7 @@ describe "Cron Job" do
           assert_equal 2, Sidekiq::Cron::Job.all('*').size, 'Should have 2 jobs'
 
           Sidekiq::Cron.configuration.available_namespaces = [custom_namespace]
-          assert_equal 1, Sidekiq::Cron::Job.all('*').size, 'Should have 1 job'
+          assert_equal 3, Sidekiq::Cron::Job.all('*').size, 'Should have 3 job'
         end
       end
     end

--- a/test/unit/namespace_test.rb
+++ b/test/unit/namespace_test.rb
@@ -54,6 +54,14 @@ describe 'Namespaces' do
 
       assert_equal %w[default namespace1 namespace2], Sidekiq::Cron::Namespace.all.sort
     end
+
+    it 'raises `ArgumentError` if unexpected `available_namespaces` value was provided' do
+      Sidekiq::Cron.configuration.available_namespaces = 42
+
+      assert_raises(ArgumentError) do
+        Sidekiq::Cron::Namespace.all
+      end
+    end
   end
 
   describe 'count' do

--- a/test/unit/namespace_test.rb
+++ b/test/unit/namespace_test.rb
@@ -28,7 +28,17 @@ describe 'Namespaces' do
   end
 
   describe 'all' do
-    it 'returns all the existing namespaces' do
+    it 'returns all the existing namespaces if `available_namespaces` is set to `nil`' do
+      Sidekiq::Cron.configuration.available_namespaces = nil
+      # new jobs!
+      Sidekiq::Cron::Job.create(args.merge(namespace: 'namespace1'))
+      Sidekiq::Cron::Job.create(args.merge(namespace: 'namespace2'))
+
+      assert_equal %w[default], Sidekiq::Cron::Namespace.all
+    end
+
+    it 'returns all the existing namespaces if `available_namespaces` is set to `auto`' do
+      Sidekiq::Cron.configuration.available_namespaces = :auto
       # new jobs!
       Sidekiq::Cron::Job.create(args.merge(namespace: 'namespace1'))
       Sidekiq::Cron::Job.create(args.merge(namespace: 'namespace2'))
@@ -48,6 +58,8 @@ describe 'Namespaces' do
 
   describe 'count' do
     it 'returns the jobs count per namespaces' do
+      Sidekiq::Cron.configuration.available_namespaces = %w[namespace1 namespace2]
+
       # new jobs!
       Sidekiq::Cron::Job.create(args.merge(namespace: 'namespace1'))
       Sidekiq::Cron::Job.create(args.merge(namespace: 'namespace2'))
@@ -66,6 +78,7 @@ describe 'Namespaces' do
 
   describe 'all_with_count' do
     it 'returns an Array of Hashes with the jobs count per namespaces' do
+      Sidekiq::Cron.configuration.available_namespaces = %w[namespace1 namespace2]
       # new jobs!
       Sidekiq::Cron::Job.create(args.merge(namespace: 'namespace1'))
       Sidekiq::Cron::Job.create(args.merge(namespace: 'namespace2'))
@@ -80,7 +93,7 @@ describe 'Namespaces' do
                   { name: 'namespace1', count: 1 },
                   { name: 'namespace2', count: 2 }]
 
-      assert_equal counts, expected
+      assert_equal expected, counts
     end
   end
 end

--- a/test/unit/web_extension_test.rb
+++ b/test/unit/web_extension_test.rb
@@ -16,6 +16,8 @@ describe 'Cron web' do
     Sidekiq::Cron.reset!
     Sidekiq.redis(&:flushdb)
 
+    Sidekiq::Cron.configuration.available_namespaces = :auto
+
     if Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new("8.0.0")
       Sidekiq::Web.configure do |c|
         # Remove CSRF protection


### PR DESCRIPTION
The default for `available_namespaces` is now `[config.default_namespaces]`.

See https://github.com/sidekiq-cron/sidekiq-cron/issues/516