### PR TITLE
Allow JSON as hash to be correctly parsed by the `Sidekiq::Cron::Job#parse_args`

### DIFF
--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -633,8 +633,7 @@ module Sidekiq
           [convert_to_global_id_hash(args)]
         when String
           begin
-            parsed_args = Sidekiq.load_json(args)
-            symbolize_args? ? symbolize_args(parsed_args) : parsed_args
+            parse_args(Sidekiq.load_json(args))
           rescue JSON::ParserError
             [*args]
           end

--- a/test/unit/job_test.rb
+++ b/test/unit/job_test.rb
@@ -1102,7 +1102,7 @@ describe "Cron Job" do
   end
 
   describe "initialize args" do
-    it "from JSON" do
+    it "from JSON as array" do
       args = {
         name: "Test",
         cron: "* * * * *",
@@ -1111,6 +1111,19 @@ describe "Cron Job" do
       }
       Sidekiq::Cron::Job.new(args).tap do |job|
         assert_equal job.args, ["123"]
+        assert_equal job.name, "Test"
+      end
+    end
+
+    it "from JSON as hash" do
+      args = {
+        name: "Test",
+        cron: "* * * * *",
+        klass: "CronTestClass",
+        args: JSON.dump({ "abc" => "123" })
+      }
+      Sidekiq::Cron::Job.new(args).tap do |job|
+        assert_equal job.args, [{ "abc" => "123" }]
         assert_equal job.name, "Test"
       end
     end
@@ -1137,6 +1150,19 @@ describe "Cron Job" do
       }
       Sidekiq::Cron::Job.new(args).tap do |job|
         assert_equal job.args, ["This is array"]
+        assert_equal job.name, "Test"
+      end
+    end
+
+    it "from Hash" do
+      args = {
+        name: "Test",
+        cron: "* * * * *",
+        klass: "CronTestClass",
+        args: { "abc" => "123" }
+      }
+      Sidekiq::Cron::Job.new(args).tap do |job|
+        assert_equal job.args, [{ "abc" => "123" }]
         assert_equal job.name, "Test"
       end
     end


### PR DESCRIPTION
Relates to:
- https://github.com/sidekiq-cron/sidekiq-cron/issues/556

This PR allows to harmonize the behavior for `Sidekiq::Cron::Job#parse_args` when using a hash directly and when a JSON representing a hash.

This allows to bring consistency with the behavior for arrays (and JSON arrays).

**This can be a considered as a breaking change if we consider people are relying on the current behavior for a JSON representing a hash for `args`.**

Indeed, `args = { "abc" => "123" }.to_json` currently gives to the worker `[ "abc", "123" ]`.

Feel free to take the relevant action for this.