### PR TITLE
Fix manually launch enqueue job not working from web ui

### DIFF
--- a/lib/sidekiq/cron/views/cron.erb
+++ b/lib/sidekiq/cron/views/cron.erb
@@ -5,22 +5,24 @@
       <small>(<%= @current_namespace %>)</small>
     </h2>
     <% if @cron_jobs.size > 0 %>
-      <form class="filter" action="<%= root_path %>cron/namespaces/<%= @current_namespace %>/all/delete" method="post">
-        <%= csrf_tag %>
-        <input class="btn btn-danger" type="submit" name="delete" value="<%= t('DeleteAll') %>" data-confirm="<%= t('AreYouSureDeleteCronJobs') %>" />
-      </form>
-      <form action="<%= root_path %>cron/namespaces/<%= @current_namespace %>/all/disable" method="post">
-        <%= csrf_tag %>
-        <input class="btn btn-primary" type="submit" name="enqueue" value="<%= t('DisableAll') %>" />
-      </form>
-      <form action="<%= root_path %>cron/namespaces/<%= @current_namespace %>/all/enable" method="post">
-        <%= csrf_tag %>
-        <input class="btn btn-primary" type="submit" name="enqueue" value="<%= t('EnableAll') %>" />
-      </form>
-      <form action="<%= root_path %>cron/namespaces/<%= @current_namespace %>/all/enqueue" method="post">
-        <%= csrf_tag %>
-        <input class="btn btn-primary" type="submit" name="enqueue" value="<%= t('EnqueueAll') %>" data-confirm="<%= t('AreYouSureEnqueueCronJobs') %>" />
-      </form>
+      <div class="filter buttons-row">
+        <form action="<%= root_path %>cron/namespaces/<%= @current_namespace %>/all/delete" method="post">
+          <%= csrf_tag %>
+          <input class="btn btn-danger" type="submit" name="delete" value="<%= t('DeleteAll') %>" data-confirm="<%= t('AreYouSureDeleteCronJobs') %>" />
+        </form>
+        <form action="<%= root_path %>cron/namespaces/<%= @current_namespace %>/all/disable" method="post">
+          <%= csrf_tag %>
+          <input class="btn btn-primary" type="submit" name="enqueue" value="<%= t('DisableAll') %>" />
+        </form>
+        <form action="<%= root_path %>cron/namespaces/<%= @current_namespace %>/all/enable" method="post">
+          <%= csrf_tag %>
+          <input class="btn btn-primary" type="submit" name="enqueue" value="<%= t('EnableAll') %>" />
+        </form>
+        <form action="<%= root_path %>cron/namespaces/<%= @current_namespace %>/all/enqueue" method="post">
+          <%= csrf_tag %>
+          <input class="btn btn-primary" type="submit" name="enqueue" value="<%= t('EnqueueAll') %>" data-confirm="<%= t('AreYouSureEnqueueCronJobs') %>" />
+        </form>
+      </div>
     <% end %>
   </header>
   <!-- Namespaces -->

--- a/lib/sidekiq/cron/views/cron.erb
+++ b/lib/sidekiq/cron/views/cron.erb
@@ -5,23 +5,21 @@
       <small>(<%= @current_namespace %>)</small>
     </h2>
     <% if @cron_jobs.size > 0 %>
-      <form class="filter">
-        <form action="<%= root_path %>cron/namespaces/<%= @current_namespace %>/all/delete" method="post">
-          <%= csrf_tag %>
-          <input class="btn btn-danger" type="submit" name="delete" value="<%= t('DeleteAll') %>" data-confirm="<%= t('AreYouSureDeleteCronJobs') %>" />
-        </form>
-        <form action="<%= root_path %>cron/namespaces/<%= @current_namespace %>/all/disable" method="post">
-          <%= csrf_tag %>
-          <input class="btn btn-primary" type="submit" name="enqueue" value="<%= t('DisableAll') %>" />
-        </form>
-        <form action="<%= root_path %>cron/namespaces/<%= @current_namespace %>/all/enable" method="post">
-          <%= csrf_tag %>
-          <input class="btn btn-primary" type="submit" name="enqueue" value="<%= t('EnableAll') %>" />
-        </form>
-        <form action="<%= root_path %>cron/namespaces/<%= @current_namespace %>/all/enqueue" method="post">
-          <%= csrf_tag %>
-          <input class="btn btn-primary" type="submit" name="enqueue" value="<%= t('EnqueueAll') %>" data-confirm="<%= t('AreYouSureEnqueueCronJobs') %>" />
-        </form>
+      <form class="filter" action="<%= root_path %>cron/namespaces/<%= @current_namespace %>/all/delete" method="post">
+        <%= csrf_tag %>
+        <input class="btn btn-danger" type="submit" name="delete" value="<%= t('DeleteAll') %>" data-confirm="<%= t('AreYouSureDeleteCronJobs') %>" />
+      </form>
+      <form action="<%= root_path %>cron/namespaces/<%= @current_namespace %>/all/disable" method="post">
+        <%= csrf_tag %>
+        <input class="btn btn-primary" type="submit" name="enqueue" value="<%= t('DisableAll') %>" />
+      </form>
+      <form action="<%= root_path %>cron/namespaces/<%= @current_namespace %>/all/enable" method="post">
+        <%= csrf_tag %>
+        <input class="btn btn-primary" type="submit" name="enqueue" value="<%= t('EnableAll') %>" />
+      </form>
+      <form action="<%= root_path %>cron/namespaces/<%= @current_namespace %>/all/enqueue" method="post">
+        <%= csrf_tag %>
+        <input class="btn btn-primary" type="submit" name="enqueue" value="<%= t('EnqueueAll') %>" data-confirm="<%= t('AreYouSureEnqueueCronJobs') %>" />
       </form>
     <% end %>
   </header>

--- a/lib/sidekiq/cron/views/cron_show.erb
+++ b/lib/sidekiq/cron/views/cron_show.erb
@@ -6,28 +6,26 @@
         <small><%= @job.name %></small>
       </h2>
     </div>
-    <form class="filter">
-      <% cron_job_path = "#{root_path}cron/namespaces/#{@current_namespace}/jobs/#{CGI.escape(@job.name).gsub('+', '%20')}" %>
-      <form action="<%= cron_job_path %>/enqueue?redirect=<%= cron_job_path %>"  method="post">
-        <%= csrf_tag %>
-        <input class="btn btn-primary" name="enqueue" type="submit" value="<%= t('EnqueueNow') %>" data-confirm="<%= t('AreYouSureEnqueueCronJob', :job => @job.name) %>" />
-      </form>
-      <% if @job.status == 'enabled' %>
-        <form action="<%= cron_job_path %>/disable?redirect=<%= cron_job_path %>"  method="post">
-          <%= csrf_tag %>
-          <input class="btn btn-primary" name="disable" type="submit" value="<%= t('Disable') %>" />
-        </form>
-      <% else %>
-        <form action="<%= cron_job_path %>/enable?redirect=<%= cron_job_path %>"  method="post">
-          <%= csrf_tag %>
-          <input class="btn btn-primary" name="enable" type="submit" value="<%= t('Enable') %>" />
-        </form>
-        <form action="<%= cron_job_path %>/delete" method="post">
-          <%= csrf_tag %>
-          <input class="btn btn-danger" data-confirm="<%= t('AreYouSureDeleteCronJob', :job => @job.name) %>" name="delete" type="submit" value="<%= t('Delete') %>" />
-        </form>
-      <% end %>
+    <% cron_job_path = "#{root_path}cron/namespaces/#{@current_namespace}/jobs/#{CGI.escape(@job.name).gsub('+', '%20')}" %>
+    <form class="filter" action="<%= cron_job_path %>/enqueue?redirect=<%= cron_job_path %>"  method="post">
+      <%= csrf_tag %>
+      <input class="btn btn-primary" name="enqueue" type="submit" value="<%= t('EnqueueNow') %>" data-confirm="<%= t('AreYouSureEnqueueCronJob', :job => @job.name) %>" />
     </form>
+    <% if @job.status == 'enabled' %>
+      <form action="<%= cron_job_path %>/disable?redirect=<%= cron_job_path %>"  method="post">
+        <%= csrf_tag %>
+        <input class="btn btn-primary" name="disable" type="submit" value="<%= t('Disable') %>" />
+      </form>
+    <% else %>
+      <form action="<%= cron_job_path %>/enable?redirect=<%= cron_job_path %>"  method="post">
+        <%= csrf_tag %>
+        <input class="btn btn-primary" name="enable" type="submit" value="<%= t('Enable') %>" />
+      </form>
+      <form action="<%= cron_job_path %>/delete" method="post">
+        <%= csrf_tag %>
+        <input class="btn btn-danger" data-confirm="<%= t('AreYouSureDeleteCronJob', :job => @job.name) %>" name="delete" type="submit" value="<%= t('Delete') %>" />
+      </form>
+    <% end %>
   </header>
   <table class="table table-bordered table-striped">
     <tbody>

--- a/lib/sidekiq/cron/views/cron_show.erb
+++ b/lib/sidekiq/cron/views/cron_show.erb
@@ -7,25 +7,27 @@
       </h2>
     </div>
     <% cron_job_path = "#{root_path}cron/namespaces/#{@current_namespace}/jobs/#{CGI.escape(@job.name).gsub('+', '%20')}" %>
-    <form class="filter" action="<%= cron_job_path %>/enqueue?redirect=<%= cron_job_path %>"  method="post">
-      <%= csrf_tag %>
-      <input class="btn btn-primary" name="enqueue" type="submit" value="<%= t('EnqueueNow') %>" data-confirm="<%= t('AreYouSureEnqueueCronJob', :job => @job.name) %>" />
-    </form>
-    <% if @job.status == 'enabled' %>
-      <form action="<%= cron_job_path %>/disable?redirect=<%= cron_job_path %>"  method="post">
+    <div class="filter buttons-row">
+      <form action="<%= cron_job_path %>/enqueue?redirect=<%= cron_job_path %>"  method="post">
         <%= csrf_tag %>
-        <input class="btn btn-primary" name="disable" type="submit" value="<%= t('Disable') %>" />
+        <input class="btn btn-primary" name="enqueue" type="submit" value="<%= t('EnqueueNow') %>" data-confirm="<%= t('AreYouSureEnqueueCronJob', :job => @job.name) %>" />
       </form>
-    <% else %>
-      <form action="<%= cron_job_path %>/enable?redirect=<%= cron_job_path %>"  method="post">
-        <%= csrf_tag %>
-        <input class="btn btn-primary" name="enable" type="submit" value="<%= t('Enable') %>" />
-      </form>
-      <form action="<%= cron_job_path %>/delete" method="post">
-        <%= csrf_tag %>
-        <input class="btn btn-danger" data-confirm="<%= t('AreYouSureDeleteCronJob', :job => @job.name) %>" name="delete" type="submit" value="<%= t('Delete') %>" />
-      </form>
-    <% end %>
+      <% if @job.status == 'enabled' %>
+        <form action="<%= cron_job_path %>/disable?redirect=<%= cron_job_path %>"  method="post">
+          <%= csrf_tag %>
+          <input class="btn btn-primary" name="disable" type="submit" value="<%= t('Disable') %>" />
+        </form>
+      <% else %>
+        <form action="<%= cron_job_path %>/enable?redirect=<%= cron_job_path %>"  method="post">
+          <%= csrf_tag %>
+          <input class="btn btn-primary" name="enable" type="submit" value="<%= t('Enable') %>" />
+        </form>
+        <form action="<%= cron_job_path %>/delete" method="post">
+          <%= csrf_tag %>
+          <input class="btn btn-danger" data-confirm="<%= t('AreYouSureDeleteCronJob', :job => @job.name) %>" name="delete" type="submit" value="<%= t('Delete') %>" />
+        </form>
+      <% end %>
+    </div>
   </header>
   <table class="table table-bordered table-striped">
     <tbody>

--- a/test/unit/web_extension_test.rb
+++ b/test/unit/web_extension_test.rb
@@ -20,8 +20,16 @@ describe 'Cron web' do
 
     if Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new("8.0.0")
       Sidekiq::Web.configure do |c|
-        # Remove CSRF protection
-        # See: https://github.com/sidekiq/sidekiq/blob/0a1bce30e562357e0bb60ce84d78fe5d8446bed9/test/webext_test.rb#L37
+        # Disable CSRF protection in Sidekiq Web.
+        #
+        # - The `c[:csrf]` setting is supported starting from Sidekiq 8.0.5.
+        #   See: https://github.com/sidekiq/sidekiq/blob/01bc5c963d9927ff27c62b118196972486a8f9a4/lib/sidekiq/web.rb#L112
+        #
+        # - `c.middlewares.clear` was previously used to remove CSRF protection,
+        #   but as of Sidekiq 8.0.4, this approach is no longer effective.
+        #   See: https://github.com/sidekiq/sidekiq/commit/ff0a840f373cf545373a34cbeacb49bf5138a2f8
+        #
+        c[:csrf] = false
         c.middlewares.clear
       end
     end


### PR DESCRIPTION
The "Enqueue Now" button was not working because HTML does not allow forms to be nested. Nesting forms can cause unexpected behavior and conflicts in form submission.

Fixes #562